### PR TITLE
fix(buttons): dual button negative visibility parameter wrong

### DIFF
--- a/app/src/main/res/layout/activity_buttons.xml
+++ b/app/src/main/res/layout/activity_buttons.xml
@@ -306,7 +306,7 @@
                 android:layout_height="wrap_content"
                 app:clickNegative="@{viewmodel::clickButton}"
                 app:clickPositive="@{viewmodel::clickButton}"
-                app:negativeInvisible="@{true}"
+                app:negativeIsInvisible="@{true}"
                 app:textNegative="@{@string/negative}"
                 app:textPositive="@{@string/positive}" />
         </LinearLayout>

--- a/ocean-components/src/main/res/layout/ocean_dual_button_blocked.xml
+++ b/ocean-components/src/main/res/layout/ocean_dual_button_blocked.xml
@@ -31,7 +31,7 @@
             type="Function0&lt;Unit>" />
 
         <variable
-            name="negativeInvisible"
+            name="negativeIsInvisible"
             type="Boolean" />
 
         <variable
@@ -49,7 +49,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:visibility="@{negativeInvisible ? View.GONE : View.VISIBLE}"
+            android:visibility="@{negativeIsInvisible ? View.GONE : View.VISIBLE}"
             app:click="@{clickNegative::invoke}"
             app:text="@{textNegative}" />
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On dual button component, the negative parameter which controls the button's visibility was with the wrong name.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Opening the button activity and changing parameters.

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
