### PR TITLE
fix: going to selection mode false on transaction list item trigger callbacks

### DIFF
--- a/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
@@ -36,6 +36,9 @@ class TransactionListItemActivity : AppCompatActivity() {
     }
 
     private fun initObservers() {
+        viewModel.selectionMode.observe(this) { isEntering ->
+            if(!isEntering) selectedItems.clear()
+        }
         viewModel.clickedItem.observe(this) { index ->
             with(selectedItems) {
                 if (isEmpty()) {

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemViewModel.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemViewModel.kt
@@ -18,4 +18,8 @@ class TransactionListItemViewModel(application: Application): AndroidViewModel(a
     fun click(index: Int) {
         _clickedItem.postValue(index)
     }
+
+    fun clear() {
+        selectionMode.postValue(false)
+    }
 }

--- a/app/src/main/res/layout/activity_transaction_list_item.xml
+++ b/app/src/main/res/layout/activity_transaction_list_item.xml
@@ -186,8 +186,13 @@
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/transactionListRecyclerView"
                     android:layout_width="match_parent"
-                    android:layout_height="match_parent" />
+                    android:layout_height="wrap_content" />
 
+                <Button
+                    android:onClick="@{() -> viewmodel.clear()}"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{`Clear`}"/>
             </androidx.appcompat.widget.LinearLayoutCompat>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/ocean-components/src/main/java/br/com/useblu/oceands/core/BindingAdapterTransactionListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/core/BindingAdapterTransactionListItem.kt
@@ -24,7 +24,7 @@ fun setClickListener(
             setCheckboxVisibleIfNot(checkbox)
             checkboxBinding?.checked = checkboxBinding?.checked?.not() ?: true
         }
-        enterOrLeaveSelectionMode(selectionMode, layout, checkbox, checkboxBinding)
+        enterOrLeaveSelectionMode(selectionMode, layout, checkbox, checkboxBinding, click, index)
         setCheckboxClick(checkboxBinding, click, index)
     } else {
         layout.setOnClickListener {
@@ -38,10 +38,8 @@ private fun setCheckboxClick(
     click: ((Int) -> Unit)?,
     index: Int?
 ) {
-    checkboxBinding?.let { binding ->
-        binding.click = {
-            click?.invoke(index ?: -1)
-        }
+    checkboxBinding?.click = {
+        click?.invoke(index ?: -1)
     }
 }
 
@@ -49,14 +47,19 @@ private fun enterOrLeaveSelectionMode(
     selectionMode: MutableLiveData<Boolean>?,
     layout: LinearLayoutCompat,
     checkbox: View,
-    checkboxBinding: OceanCheckboxBinding?
+    checkboxBinding: OceanCheckboxBinding?,
+    click: ((Int) -> Unit)?,
+    index: Int?
 ) {
     selectionMode?.observe(layout.context as LifecycleOwner) { isEntering ->
         if (isEntering) {
             setCheckboxVisibleIfNot(checkbox)
         } else {
+            checkboxBinding?.click = {}
             checkbox.visibility = View.GONE
             checkboxBinding?.checked = false
+            checkboxBinding?.executePendingBindings()
+            setCheckboxClick(checkboxBinding, click, index)
         }
     }
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

When going off from selection mode, the change on checkbox was triggering the callbacks.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Clicking button on the `MainActivity` to set selection mode to false.

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
