### PR TITLE
feat: make chips parameter a live data on ocean chips list

### DIFF
--- a/app/src/main/java/br/com/useblu/oceands/client/ui/chips/ChipsActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/chips/ChipsActivity.kt
@@ -20,6 +20,7 @@ class ChipsActivity : AppCompatActivity() {
         viewModel = ViewModelProvider(this)[ChipsViewModel::class.java]
         binding.viewmodel = viewModel
         initObservers()
+        viewModel.loadData()
     }
 
     private fun initObservers() {

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/chips/ChipsViewModel.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/chips/ChipsViewModel.kt
@@ -4,14 +4,17 @@ import android.app.Application
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import br.com.useblu.oceands.adapter.Badge
 import br.com.useblu.oceands.adapter.OceanChipItem
 import br.com.useblu.oceands.adapter.OceanChipItemState
 import br.com.useblu.oceands.client.R
 import br.com.useblu.oceands.client.ui.chips.model.ChipModel
 import br.com.useblu.oceands.core.OceanBadgeType
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-class ChipsViewModel(application: Application): AndroidViewModel(application) {
+class ChipsViewModel(application: Application) : AndroidViewModel(application) {
     private val allChip = ChipModel(
         id = "all",
         label = "Todos"
@@ -32,7 +35,145 @@ class ChipsViewModel(application: Application): AndroidViewModel(application) {
         id = "error",
         label = "Erro"
     )
-    val chips: ArrayList<OceanChipItem> = arrayListOf(
+    val chips: MutableLiveData<ArrayList<OceanChipItem>> = MutableLiveData(
+        arrayListOf(
+            OceanChipItem(
+                label = allChip.label,
+                id = allChip.id
+            ),
+            OceanChipItem(
+                label = toDueChip.label,
+                id = toDueChip.id
+            ),
+            OceanChipItem(
+                label = overDueChip.label,
+                id = overDueChip.id
+            ),
+            OceanChipItem(
+                label = unavailableChip.label,
+                id = unavailableChip.id,
+                state = OceanChipItemState.DISABLED
+            ),
+            OceanChipItem(
+                label = errorChip.label,
+                id = errorChip.id,
+                state = OceanChipItemState.ERROR
+            )
+        )
+    )
+
+    val chipsWithIcon: MutableLiveData<ArrayList<OceanChipItem>> = MutableLiveData(
+        arrayListOf(
+            OceanChipItem(
+                label = allChip.label,
+                id = allChip.id,
+                icon = ContextCompat.getDrawable(
+                    getApplication<Application>(),
+                    R.drawable.icon_information
+                )
+            ),
+            OceanChipItem(
+                label = toDueChip.label,
+                id = toDueChip.id,
+                icon = ContextCompat.getDrawable(
+                    getApplication<Application>(),
+                    R.drawable.icon_information
+                )
+            ),
+            OceanChipItem(
+                label = overDueChip.label,
+                id = overDueChip.id,
+                icon = ContextCompat.getDrawable(
+                    getApplication<Application>(),
+                    R.drawable.icon_information
+                )
+            ),
+            OceanChipItem(
+                label = unavailableChip.label,
+                id = unavailableChip.id,
+                state = OceanChipItemState.DISABLED,
+                icon = ContextCompat.getDrawable(
+                    getApplication<Application>(),
+                    R.drawable.icon_information
+                )
+            ),
+            OceanChipItem(
+                label = errorChip.label,
+                id = errorChip.id,
+                state = OceanChipItemState.ERROR,
+                icon = ContextCompat.getDrawable(
+                    getApplication<Application>(),
+                    R.drawable.icon_information
+                )
+            )
+        )
+    )
+
+    val chipsWithBadge: MutableLiveData<ArrayList<OceanChipItem>> = MutableLiveData(
+        arrayListOf(
+            OceanChipItem(
+                label = allChip.label,
+                id = allChip.id,
+                badge = Badge(100, OceanBadgeType.ALERT)
+            ),
+            OceanChipItem(
+                label = toDueChip.label,
+                id = toDueChip.id,
+                badge = Badge(50, OceanBadgeType.ALERT)
+            ),
+            OceanChipItem(
+                label = overDueChip.label,
+                id = overDueChip.id,
+                badge = Badge(0, OceanBadgeType.ALERT)
+            ),
+            OceanChipItem(
+                label = unavailableChip.label,
+                id = unavailableChip.id,
+                state = OceanChipItemState.DISABLED,
+                badge = Badge(9, OceanBadgeType.ALERT)
+            ),
+            OceanChipItem(
+                label = errorChip.label,
+                id = errorChip.id,
+                state = OceanChipItemState.ERROR,
+                badge = Badge(9, OceanBadgeType.ALERT)
+            )
+        )
+    )
+
+    val chipsWithClose: MutableLiveData<ArrayList<OceanChipItem>> = MutableLiveData(
+        arrayListOf(
+            OceanChipItem(
+                label = allChip.label,
+                id = allChip.id,
+                hasClose = true
+            ),
+            OceanChipItem(
+                label = toDueChip.label,
+                id = toDueChip.id,
+                hasClose = true
+            ),
+            OceanChipItem(
+                label = overDueChip.label,
+                id = overDueChip.id,
+                hasClose = true
+            ),
+            OceanChipItem(
+                label = unavailableChip.label,
+                id = unavailableChip.id,
+                state = OceanChipItemState.DISABLED,
+                hasClose = true
+            ),
+            OceanChipItem(
+                label = errorChip.label,
+                id = errorChip.id,
+                state = OceanChipItemState.ERROR,
+                hasClose = true
+            )
+        )
+    )
+
+    val chipsArrayList = arrayListOf(
         OceanChipItem(
             label = allChip.label,
             id = allChip.id
@@ -57,96 +198,16 @@ class ChipsViewModel(application: Application): AndroidViewModel(application) {
         )
     )
 
-    val chipsWithIcon: ArrayList<OceanChipItem> = arrayListOf(
-        OceanChipItem(
-            label = allChip.label,
-            id = allChip.id,
-            icon = ContextCompat.getDrawable(getApplication<Application>(), R.drawable.icon_information)
-        ),
-        OceanChipItem(
-            label = toDueChip.label,
-            id = toDueChip.id,
-            icon = ContextCompat.getDrawable(getApplication<Application>(), R.drawable.icon_information)
-        ),
-        OceanChipItem(
-            label = overDueChip.label,
-            id = overDueChip.id,
-            icon = ContextCompat.getDrawable(getApplication<Application>(), R.drawable.icon_information)
-        ),
-        OceanChipItem(
-            label = unavailableChip.label,
-            id = unavailableChip.id,
-            state = OceanChipItemState.DISABLED,
-            icon = ContextCompat.getDrawable(getApplication<Application>(), R.drawable.icon_information)
-        ),
-        OceanChipItem(
-            label = errorChip.label,
-            id = errorChip.id,
-            state = OceanChipItemState.ERROR,
-            icon = ContextCompat.getDrawable(getApplication<Application>(), R.drawable.icon_information)
-        )
-    )
-
-    val chipsWithBadge: ArrayList<OceanChipItem> = arrayListOf(
-        OceanChipItem(
-            label = allChip.label,
-            id = allChip.id,
-            badge = Badge(100, OceanBadgeType.ALERT)
-        ),
-        OceanChipItem(
-            label = toDueChip.label,
-            id = toDueChip.id,
-            badge = Badge(50, OceanBadgeType.ALERT)
-        ),
-        OceanChipItem(
-            label = overDueChip.label,
-            id = overDueChip.id,
-            badge = Badge(0, OceanBadgeType.ALERT)
-        ),
-        OceanChipItem(
-            label = unavailableChip.label,
-            id = unavailableChip.id,
-            state = OceanChipItemState.DISABLED,
-            badge = Badge(9, OceanBadgeType.ALERT)
-        ),
-        OceanChipItem(
-            label = errorChip.label,
-            id = errorChip.id,
-            state = OceanChipItemState.ERROR,
-            badge = Badge(9, OceanBadgeType.ALERT)
-        )
-    )
-
-    val chipsWithClose: ArrayList<OceanChipItem> = arrayListOf(
-        OceanChipItem(
-            label = allChip.label,
-            id = allChip.id,
-            hasClose = true
-        ),
-        OceanChipItem(
-            label = toDueChip.label,
-            id = toDueChip.id,
-            hasClose = true
-        ),
-        OceanChipItem(
-            label = overDueChip.label,
-            id = overDueChip.id,
-            hasClose = true
-        ),
-        OceanChipItem(
-            label = unavailableChip.label,
-            id = unavailableChip.id,
-            state = OceanChipItemState.DISABLED,
-            hasClose = true
-        ),
-        OceanChipItem(
-            label = errorChip.label,
-            id = errorChip.id,
-            state = OceanChipItemState.ERROR,
-            hasClose = true
-        )
-    )
-
     private val _selectedItem: MutableLiveData<OceanChipItem?> = MutableLiveData()
     val selectedItem: MutableLiveData<OceanChipItem?> get() = _selectedItem
+
+    private val _chips: MutableLiveData<ArrayList<OceanChipItem>> = MutableLiveData(ArrayList())
+    val chipsLiveData: MutableLiveData<ArrayList<OceanChipItem>> get() = _chips
+
+    fun loadData() {
+        viewModelScope.launch {
+            delay(3000)
+            _chips.postValue(chipsArrayList)
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_chips.xml
+++ b/app/src/main/res/layout/activity_chips.xml
@@ -51,5 +51,14 @@
             layout="@layout/ocean_chip_list"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <include
+            android:id="@+id/livedata"
+            app:chips="@{viewmodel.chipsLiveData}"
+            app:selectedItem="@{viewmodel.selectedItem}"
+            app:itemsSpacing="@{@dimen/ocean_spacing_stack_xxs}"
+            layout="@layout/ocean_chip_list"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
     </LinearLayout>
 </layout>

--- a/ocean-components/src/main/java/br/com/useblu/oceands/adapter/OceanChipListAdapter.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/adapter/OceanChipListAdapter.kt
@@ -12,7 +12,7 @@ import br.com.useblu.oceands.core.OceanBadgeType
 import br.com.useblu.oceands.databinding.OceanChipListItemBinding
 
 class OceanChipListAdapter(
-    val items: ArrayList<OceanChipItem>,
+    var items: ArrayList<OceanChipItem>,
     val selectedItem: MutableLiveData<OceanChipItem>
 ) : RecyclerView.Adapter<OceanChipListAdapter.OceanChipListViewHolder>() {
 
@@ -38,6 +38,12 @@ class OceanChipListAdapter(
     }
 
     override fun getItemCount(): Int = items.size
+
+    @SuppressLint("NotifyDataSetChanged")
+    fun setData(items: ArrayList<OceanChipItem>) {
+        this.items = items
+        notifyDataSetChanged()
+    }
 
     inner class OceanChipListViewHolder(
         private val itemBinding: OceanChipListItemBinding
@@ -137,7 +143,7 @@ class OceanChipListAdapter(
         private fun setBadge(item: OceanChipItem) {
             item.badge ?: return
             if (item.badge.text > 0) return
-            
+
             item.badge.type = OceanBadgeType.NEUTRAL
         }
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/core/BindingAdapterChip.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/core/BindingAdapterChip.kt
@@ -5,6 +5,7 @@ import android.graphics.Rect
 import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.databinding.BindingAdapter
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MutableLiveData
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -16,12 +17,18 @@ import br.com.useblu.oceands.adapter.OceanChipListAdapter
 @BindingAdapter("chips", "selectedItem", "itemsSpacing")
 fun setChipsAdapter(
     recyclerView: RecyclerView,
-    chips: ArrayList<OceanChipItem>,
+    chips: MutableLiveData<ArrayList<OceanChipItem>>,
     selectedItem: MutableLiveData<OceanChipItem>,
     itemsSpacing: Float
 ) {
+    chips.observe(recyclerView.context as LifecycleOwner) { newChips ->
+        (recyclerView.adapter as OceanChipListAdapter?)?.setData(newChips)
+    }
     if (recyclerView.adapter == null) {
-        val adapter = OceanChipListAdapter(chips, selectedItem)
+        val adapter = OceanChipListAdapter(
+            chips.value ?: ArrayList(),
+            selectedItem
+        )
         val layoutManager =
             LinearLayoutManager(recyclerView.context, LinearLayoutManager.HORIZONTAL, false)
         val divider = ItemsDivider(recyclerView.context, layoutManager.orientation, itemsSpacing)
@@ -35,7 +42,11 @@ fun setChipsAdapter(
     }
 }
 
-class ItemsDivider(private val context: Context, orientation: Int, private val itemsSpacing: Float) :
+class ItemsDivider(
+    context: Context,
+    orientation: Int,
+    private val itemsSpacing: Float
+) :
     DividerItemDecoration(context, orientation) {
     override fun getItemOffsets(
         outRect: Rect,

--- a/ocean-components/src/main/res/layout/ocean_chip_list.xml
+++ b/ocean-components/src/main/res/layout/ocean_chip_list.xml
@@ -15,7 +15,7 @@
 
         <variable
             name="chips"
-            type="ArrayList&lt;OceanChipItem>" />
+            type="MutableLiveData&lt;ArrayList&lt;OceanChipItem>>" />
 
         <variable
             name="selectedItem"

--- a/ocean-components/src/main/res/layout/ocean_chip_list_item.xml
+++ b/ocean-components/src/main/res/layout/ocean_chip_list_item.xml
@@ -43,9 +43,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="@dimen/ocean_spacing_inline_xxxs"
+            app:isSmall="@{true}"
             app:text="@{item.badge != null ? Integer.toString(item.badge.text) : @string/empty}"
             app:type="@{item.badge != null ? item.badge.type : OceanBadgeType.DEFAULT}"
-            app:isSmall="@{true}"
             app:visible="@{item.badge != null}" />
 
         <ImageView
@@ -63,21 +63,21 @@
             android:id="@+id/label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textAlignment="center"
             android:fontFamily="@font/font_family_base_medium"
             android:gravity="center"
             android:text="@{item.label}"
+            android:textAlignment="center"
             android:textSize="@dimen/ocean_font_size_xxs"
             tools:text="Todos"
             tools:textColor="@color/ocean_color_interface_light_up" />
 
         <ImageView
-            android:scaleType="center"
             android:id="@+id/closeIcon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:layout_marginStart="@dimen/ocean_spacing_inline_xxxs"
+            android:scaleType="center"
             android:src="@drawable/icon_clear"
             android:visibility="@{item.hasClose ? View.VISIBLE : View.GONE}"
             app:tint="@color/ocean_color_brand_primary_down"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Transform chips parameter from ocean chips list a livedata. It will enable to change the chips after the component were created.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Opening the `MainActivity` and going to option `Chips`. A value is post on the livedata after 3 seconds and a new row with the posted item will appear.

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
