### PR TITLE
fix: consultoutline added to extension file and fix searchsolid icons

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/utils/ExtensionsIcons.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/utils/ExtensionsIcons.kt
@@ -1063,7 +1063,7 @@ fun String.toOceanIcon() = when (this.lowercase()) {
         R.drawable.ocean_icon_search_outline
     }
     "searchsolid" -> {
-        R.drawable.ocean_icon_search_circle_solid
+        R.drawable.ocean_icon_search_solid
     }
     "selectoroutline" -> {
         R.drawable.ocean_icon_selector_outline

--- a/ocean-components/src/main/java/br/com/useblu/oceands/utils/ExtensionsIcons.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/utils/ExtensionsIcons.kt
@@ -1395,6 +1395,9 @@ fun String.toOceanIcon() = when (this.lowercase()) {
     "constructionmaterialoutline" -> {
         R.drawable.ocean_icon_construction_material_outline
     }
+    "consultoutline" -> {
+        R.drawable.ocean_icon_consult_outline
+    }
     "contactbookoutline" -> {
         R.drawable.ocean_icon_contact_book_outline
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- The Consult Outline icon was in the project, but was not in the Extensions file.
- The Search Solid icon was pointing to the Circle Seach Outline icon


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

## Checklist:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed
