### PR TITLE
fix: typo on default icon for text list item

### DIFF
--- a/ocean-components/src/main/res/layout/ocean_text_list_item.xml
+++ b/ocean-components/src/main/res/layout/ocean_text_list_item.xml
@@ -339,7 +339,7 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:tint="@color/ocean_color_interface_dark_up"
                 app:ocean_visible_or_gone="@{arrowVisible &amp;&amp; !disabled}"
-                app:ocean_icon='@{rightIcon != null ? rightIcon : "chevonrightsolid"}'
+                app:ocean_icon='@{rightIcon != null ? rightIcon : "chevronrightsolid"}'
                 app:srcCompat="@drawable/icon_chevron_right" />
 
             <ImageView


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The default image for the right icon had a typo: 
<img width="330" alt="SubTitle" src="https://user-images.githubusercontent.com/15229294/215583506-d35347c7-5d3a-4a60-8680-0d00795a5dfc.png">

After the fix:
<img width="330" alt="Title Badge" src="https://user-images.githubusercontent.com/15229294/215583555-e58d8573-b0ad-4a19-b570-5845b4e279ef.png">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
