### PR TITLE
fix: fix ocean shortcut badge showing always

### DIFF
--- a/ocean-components/src/main/res/layout/item_shortcuts_adapter_ocean.xml
+++ b/ocean-components/src/main/res/layout/item_shortcuts_adapter_ocean.xml
@@ -52,18 +52,17 @@
                     tools:src="@drawable/icon_generic_primary" />
 
                 <include
+                    layout="@layout/ocean_badge"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/ocean_spacing_inline_xxs"
                     android:layout_marginEnd="@dimen/ocean_spacing_inline_xxs"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:ocean_visible_or_gone="@{item.showBadge}"
-                    layout="@layout/ocean_badge"
                     app:isSmall="@{false}"
                     app:text="@{item.count}"
                     app:type="@{item.badgeType}"
-                    app:visible="@{true}"
+                    app:visible="@{item.showBadge}"
                     tools:visibility="visible" />
 
                 <ImageView


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

OceanShortcutItem's badge was showing always

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

## Checklist:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed
