### PR TITLE
Feat/implementing ocean alert

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanAlert.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanAlert.kt
@@ -1,0 +1,381 @@
+package br.com.useblu.oceands.components.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import br.com.useblu.oceands.model.compose.AlertStyle
+import br.com.useblu.oceands.model.compose.OceanAlertType
+import br.com.useblu.oceands.ui.compose.OceanColors
+
+
+@Preview
+@Composable
+fun OceanAlertPreview() {
+    Column(
+        modifier = Modifier
+            .background(color = OceanColors.interfaceLightPure)
+            .padding(8.dp)
+            .verticalScroll(
+                rememberScrollState()
+            ),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OceanAlert(
+            style = OceanAlertType.Default(
+                description = "Default Alert Info",
+                alertType = AlertStyle.StyleInfo(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Default(
+                description = "Default Alert Warning",
+                alertType = AlertStyle.StyleWarning(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Default(
+                description = "Default Alert Positive",
+                alertType = AlertStyle.StylePositive(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Default(
+                description = "Default Alert Negative",
+                alertType = AlertStyle.StyleNegative(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledShort(
+                title = "Entitled Alert",
+                description = "Entitled Alert Short",
+                alertType = AlertStyle.StyleInfo(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledShort(
+                title = "Entitled Alert",
+                description = "Entitled Alert Short",
+                alertType = AlertStyle.StyleWarning(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledShort(
+                title = "Entitled Alert",
+                description = "Entitled Alert Short",
+                alertType = AlertStyle.StylePositive(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledShort(
+                title = "Entitled Alert",
+                description = "Entitled Alert Short",
+                alertType = AlertStyle.StyleNegative(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledLong(
+                title = "Entitled Alert",
+                description = "Entitled Alert Long",
+                alertType = AlertStyle.StyleInfo(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledLong(
+                title = "Entitled Alert",
+                description = "Entitled Alert Long",
+                alertType = AlertStyle.StyleWarning(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledLong(
+                title = "Entitled Alert",
+                description = "Entitled Alert Long",
+                alertType = AlertStyle.StylePositive(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.EntitledLong(
+                title = "Entitled Alert",
+                description = "Entitled Alert Long",
+                alertType = AlertStyle.StyleNegative(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleInfo(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleWarning(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StylePositive(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleNegative(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                title = "Entitled Alert",
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleInfo(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                title = "Entitled Alert",
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleWarning(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                title = "Entitled Alert",
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StylePositive(),
+            )
+        )
+        OceanAlert(
+            style = OceanAlertType.Labeled(
+                title = "Entitled Alert",
+                description = "Entitled Alert Labeled",
+                label = "Label",
+                alertType = AlertStyle.StyleNegative(),
+            )
+        )
+    }
+}
+
+
+@Composable
+fun OceanAlert(
+    modifier: Modifier = Modifier,
+    style: OceanAlertType,
+) {
+    Column(modifier = modifier) {
+        when (style) {
+            is OceanAlertType.Default -> {
+                OceanAlertDefaultStyle(
+                    description = style.description,
+                    alertType = style.alertType,
+                )
+            }
+
+            is OceanAlertType.EntitledShort -> {
+                OceanAlertEntitledShort(
+                    title = style.title,
+                    description = style.description,
+                    alertType = style.alertType,
+                )
+            }
+
+            is OceanAlertType.EntitledLong -> {
+                OceanAlertEntitledLong(
+                    title = style.title,
+                    description = style.description,
+                    alertType = style.alertType,
+                )
+            }
+
+            is OceanAlertType.Labeled -> {
+                OceanAlertLabeled(
+                    title = style.title,
+                    description = style.description,
+                    label = style.label,
+                    alertType = style.alertType,
+                    onClickLable = { }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun OceanAlertDefaultStyle(
+    description: String,
+    alertType: AlertStyle,
+) {
+    Row(
+        verticalAlignment = CenterVertically,
+        modifier = Modifier
+            .background(
+                color = alertType.alertBackgroundColor.invoke(),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Icon(
+            modifier = Modifier.padding(end = 8.dp),
+            painter = painterResource(id = alertType.oceanIcon.icon),
+            tint = alertType.iconTint.invoke(),
+            contentDescription = null,
+        )
+        Text(
+            text = description,
+            style = alertType.descriptionStyle.invoke(),
+            color = alertType.descriptionColor.invoke(),
+            maxLines = 2,
+        )
+    }
+}
+
+@Composable
+fun OceanAlertEntitledShort(
+    title: String,
+    description: String,
+    alertType: AlertStyle,
+) {
+    Row(
+        verticalAlignment = CenterVertically,
+        modifier = Modifier
+            .background(
+                color = alertType.alertBackgroundColor.invoke(),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Column {
+            Icon(
+                modifier = Modifier.padding(end = 8.dp),
+                painter = painterResource(id = alertType.oceanIcon.icon),
+                tint = alertType.iconTint.invoke(),
+                contentDescription = null,
+            )
+        }
+        Column {
+            Text(
+                text = title,
+                style = alertType.titleStyle.invoke(),
+                color = alertType.titleColor.invoke(),
+                maxLines = 2,
+            )
+            Text(
+                text = description,
+                style = alertType.descriptionStyle.invoke(),
+                color = alertType.descriptionColor.invoke(),
+                maxLines = 2,
+            )
+        }
+    }
+}
+
+@Composable
+fun OceanAlertEntitledLong(
+    title: String,
+    description: String,
+    alertType: AlertStyle,
+) {
+    Column(
+        modifier = Modifier
+            .background(
+                color = alertType.alertBackgroundColor.invoke(),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(bottom = 12.dp),
+            verticalAlignment = CenterVertically,
+        ) {
+            Icon(
+                modifier = Modifier.padding(end = 8.dp),
+                painter = painterResource(id = alertType.oceanIcon.icon),
+                tint = alertType.iconTint.invoke(),
+                contentDescription = null,
+            )
+            Text(
+                text = title,
+                style = alertType.titleStyle.invoke(),
+                color = alertType.titleColor.invoke(),
+                maxLines = 2,
+            )
+        }
+        Text(
+            text = description,
+            style = alertType.descriptionStyle.invoke(),
+            color = alertType.descriptionColor.invoke(),
+            maxLines = 2,
+        )
+    }
+}
+
+@Composable
+fun OceanAlertLabeled(
+    title: String? = null,
+    description: String,
+    label: String,
+    alertType: AlertStyle,
+    onClickLable: () -> Unit
+) {
+    Row(
+        verticalAlignment = CenterVertically,
+        modifier = Modifier
+            .background(
+                color = alertType.alertBackgroundColor.invoke(),
+                shape = RoundedCornerShape(8.dp)
+            )
+            .padding(16.dp)
+    ) {
+        Column {
+            Icon(
+                modifier = Modifier.padding(end = 8.dp),
+                painter = painterResource(id = alertType.oceanIcon.icon),
+                tint = alertType.iconTint.invoke(),
+                contentDescription = null,
+            )
+        }
+        Column {
+            if (title != null) {
+                Text(
+                    text = title,
+                    style = alertType.titleStyle.invoke(),
+                    color = alertType.titleColor.invoke(),
+                    maxLines = 2,
+                )
+            }
+            Text(
+                text = description,
+                style = alertType.descriptionStyle.invoke(),
+                color = alertType.descriptionColor.invoke(),
+                maxLines = 2,
+            )
+            OceanLink(
+                modifier = Modifier.padding(top = 12.dp),
+                text = label,
+                isSmall = true,
+                linkIcon = OceanLinkIcon.DEFAULT,
+                onClick = onClickLable
+            )
+        }
+    }
+}

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanAlert.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanAlert.kt
@@ -60,115 +60,115 @@ fun OceanAlertPreview() {
         OceanAlert(
             style = OceanAlertType.EntitledShort(
                 title = "Entitled Alert",
-                description = "Entitled Alert Short",
+                description = "Entitled Alert Short Info",
                 alertType = AlertStyle.StyleInfo(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledShort(
                 title = "Entitled Alert",
-                description = "Entitled Alert Short",
+                description = "Entitled Alert Short Warning",
                 alertType = AlertStyle.StyleWarning(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledShort(
                 title = "Entitled Alert",
-                description = "Entitled Alert Short",
+                description = "Entitled Alert Short Positive",
                 alertType = AlertStyle.StylePositive(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledShort(
                 title = "Entitled Alert",
-                description = "Entitled Alert Short",
+                description = "Entitled Alert Short Negative",
                 alertType = AlertStyle.StyleNegative(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledLong(
                 title = "Entitled Alert",
-                description = "Entitled Alert Long",
+                description = "Entitled Alert Long Info",
                 alertType = AlertStyle.StyleInfo(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledLong(
                 title = "Entitled Alert",
-                description = "Entitled Alert Long",
+                description = "Entitled Alert Long Warning",
                 alertType = AlertStyle.StyleWarning(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledLong(
                 title = "Entitled Alert",
-                description = "Entitled Alert Long",
+                description = "Entitled Alert Long Positive",
                 alertType = AlertStyle.StylePositive(),
             )
         )
         OceanAlert(
             style = OceanAlertType.EntitledLong(
                 title = "Entitled Alert",
-                description = "Entitled Alert Long",
+                description = "Entitled Alert Long Negative",
                 alertType = AlertStyle.StyleNegative(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                description = "Entitled Alert Labeled",
+                description = "Untitled Alert Labeled Info",
                 label = "Label",
                 alertType = AlertStyle.StyleInfo(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                description = "Entitled Alert Labeled",
+                description = "Untitled Alert Labeled Warning",
                 label = "Label",
                 alertType = AlertStyle.StyleWarning(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                description = "Entitled Alert Labeled",
+                description = "Untitled Alert Labeled Positive",
                 label = "Label",
                 alertType = AlertStyle.StylePositive(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                description = "Entitled Alert Labeled",
+                description = "Untitled Alert Labeled Negative",
                 label = "Label",
                 alertType = AlertStyle.StyleNegative(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                title = "Entitled Alert",
-                description = "Entitled Alert Labeled",
+                title = "Labeled Alert",
+                description = "Entitled Alert Labeled Info",
                 label = "Label",
                 alertType = AlertStyle.StyleInfo(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                title = "Entitled Alert",
-                description = "Entitled Alert Labeled",
+                title = "Labeled Alert",
+                description = "Entitled Alert Labeled Warning",
                 label = "Label",
                 alertType = AlertStyle.StyleWarning(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                title = "Entitled Alert",
-                description = "Entitled Alert Labeled",
+                title = "Labeled Alert",
+                description = "Entitled Alert Labeled Positive",
                 label = "Label",
                 alertType = AlertStyle.StylePositive(),
             )
         )
         OceanAlert(
             style = OceanAlertType.Labeled(
-                title = "Entitled Alert",
-                description = "Entitled Alert Labeled",
+                title = "Labeled Alert",
+                description = "Entitled Alert Labeled Negative",
                 label = "Label",
                 alertType = AlertStyle.StyleNegative(),
             )

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanAlertType.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanAlertType.kt
@@ -1,0 +1,85 @@
+package br.com.useblu.oceands.model.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
+import br.com.useblu.oceands.utils.OceanIcons
+
+sealed interface OceanAlertType {
+    class Default(
+        val alertType: AlertStyle = AlertStyle.StyleInfo(),
+        val description: String
+    ): OceanAlertType
+
+    class EntitledShort(
+        val alertType: AlertStyle = AlertStyle.StyleInfo(),
+        val title: String,
+        val description: String
+    ): OceanAlertType
+
+    class EntitledLong(
+        val alertType: AlertStyle = AlertStyle.StyleInfo(),
+        val title: String,
+        val description: String
+    ): OceanAlertType
+
+    class Labeled(
+        val alertType: AlertStyle = AlertStyle.StyleInfo(),
+        val title: String? = null,
+        val description: String,
+        val label: String
+    ): OceanAlertType
+}
+
+sealed interface AlertStyle {
+
+    val titleColor: @Composable () -> Color
+    val titleStyle: @Composable () -> TextStyle
+    val descriptionStyle: @Composable () -> TextStyle
+    val descriptionColor: @Composable () -> Color
+    val alertBackgroundColor: @Composable () -> Color
+    val oceanIcon: OceanIcons
+    val iconTint: @Composable () -> Color
+
+    class StyleInfo (
+        override val titleColor: @Composable () -> Color = { OceanColors.brandPrimaryDown },
+        override val titleStyle: @Composable () -> TextStyle = { OceanTextStyle.heading5 },
+        override val descriptionStyle: @Composable () -> TextStyle = { OceanTextStyle.caption },
+        override val descriptionColor: @Composable () -> Color = { OceanColors.interfaceDarkDown },
+        override val alertBackgroundColor: @Composable () -> Color = { OceanColors.interfaceLightUp },
+        override val oceanIcon: OceanIcons = OceanIcons.INFO_OUTLINE,
+        override val iconTint: @Composable () -> Color = { OceanColors.brandPrimaryDown }
+    ) : AlertStyle
+
+    class StyleWarning (
+        override val titleColor: @Composable () -> Color = { OceanColors.statusWarningDeep },
+        override val titleStyle: @Composable () -> TextStyle = { OceanTextStyle.heading5 },
+        override val descriptionStyle: @Composable () -> TextStyle = { OceanTextStyle.caption },
+        override val descriptionColor: @Composable () -> Color = { OceanColors.interfaceDarkDown },
+        override val alertBackgroundColor: @Composable () -> Color = { OceanColors.statusWarningUp },
+        override val oceanIcon: OceanIcons = OceanIcons.EXCLAMATION_CIRCLE_OUTLINE,
+        override val iconTint: @Composable () -> Color = { OceanColors.statusWarningDeep }
+    ) : AlertStyle
+
+    class StylePositive (
+        override val titleColor: @Composable () -> Color = { OceanColors.statusPositiveDeep },
+        override val titleStyle: @Composable () -> TextStyle = { OceanTextStyle.heading5 },
+        override val descriptionStyle: @Composable () -> TextStyle = { OceanTextStyle.caption },
+        override val descriptionColor: @Composable () -> Color = { OceanColors.interfaceDarkDown },
+        override val alertBackgroundColor: @Composable () -> Color = { OceanColors.statusPositiveUp },
+        override val oceanIcon: OceanIcons = OceanIcons.CHECK_CIRCLE_OUTLINE,
+        override val iconTint: @Composable () -> Color = { OceanColors.statusPositiveDeep }
+    ) : AlertStyle
+
+    class StyleNegative (
+        override val titleColor: @Composable () -> Color = { OceanColors.statusNegativePure },
+        override val titleStyle: @Composable () -> TextStyle = { OceanTextStyle.heading5 },
+        override val descriptionStyle: @Composable () -> TextStyle = { OceanTextStyle.caption },
+        override val descriptionColor: @Composable () -> Color = { OceanColors.interfaceDarkDown },
+        override val alertBackgroundColor: @Composable () -> Color = { OceanColors.statusNegativeUp },
+        override val oceanIcon: OceanIcons = OceanIcons.X_CIRCLE_OUTLINE,
+        override val iconTint: @Composable () -> Color = { OceanColors.statusNegativePure }
+    ) : AlertStyle
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implementing OceanAlert

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

<table>
    <tr>
      <td style="padding:10px"> 
           <img width="150" alt="Captura de Tela 2023-09-20 às 10 32 08" src="https://github.com/ocean-ds/ocean-android/assets/38379044/17a5b07f-0a9b-4ec2-b86a-504091e00ac6">
      </td>
      <td style="padding:10px"> 
           <img width="150" alt="Captura de Tela 2023-09-20 às 10 32 20" src="https://github.com/ocean-ds/ocean-android/assets/38379044/57f9b41a-0a15-4474-8961-bd1806e90ca7">
      </td>
      <td style="padding:10px"> 
           <img width="150" alt="Captura de Tela 2023-09-20 às 10 32 32" src="https://github.com/ocean-ds/ocean-android/assets/38379044/a035c250-ded3-41d9-8e67-92cfcf9f6e16">
      </td>
    </tr>
    <tr>
      <td style="padding:10px"> 
           <img width="150" alt="Captura de Tela 2023-09-20 às 10 32 56" src="https://github.com/ocean-ds/ocean-android/assets/38379044/cf618c6e-50fb-4475-b889-14e662fefeb2">
      </td>
      <td style="padding:10px"> 
           <img width="150" alt="Captura de Tela 2023-09-20 às 10 33 16" src="https://github.com/ocean-ds/ocean-android/assets/38379044/4ee3e405-db6a-464e-8cba-277defc040cf">
      </td>
    </tr>
</table>

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
