### PR TITLE
fix: adjusting divider exhibition when text list is selectable

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTextListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTextListItem.kt
@@ -41,6 +41,7 @@ private fun OceanTextListItemPreview() {
             state = rememberScrollState(),
             enabled = true
         )
+        .background(color = OceanColors.interfaceLightPure)
     ) {
         OceanTextListItem(
             modifier = Modifier,
@@ -294,10 +295,13 @@ fun OceanTextListItem(
                 }
             }
         }
-        Divider(
-            thickness = 1.dp,
-            color = OceanColors.interfaceLightDown
-        )
+
+        if(textListStyle != OceanTextListStyle.DEFAULT){
+            Divider(
+                thickness = 1.dp,
+                color = OceanColors.interfaceLightDown
+            )
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adjusting exhibition of the divider to show only when text list is not selectable.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

 - Manually 

## Screenshots (if appropriate):

<table>
    <tr>
      <td style="padding:10px"> 
           <img width="200" alt="Captura de Tela 2023-11-23 às 10 25 33" src="https://github.com/ocean-ds/ocean-android/assets/38379044/25e3bc8e-868d-4b2e-b03a-795e583e5670">
      </td>
    </tr>
</table>

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
