### PR TITLE
fix: downgrade compose version so ProgressIndicator does not crash

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
@@ -15,6 +15,10 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -111,13 +115,17 @@ fun PreviewButton() {
                 }
             )
 
+            var isLoading by remember {
+                mutableStateOf(false)
+            }
             OceanButton(
                 text = "Permitir",
-                showProgress = false,
+                showProgress = isLoading,
                 modifier = Modifier.padding(top = 16.dp).width(200.dp),
                 buttonStyle = OceanButtonStyle.PrimaryMedium,
                 onClick = {
                     println("Botão clicado")
+                    isLoading = true
                 }
             )
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,7 +55,7 @@ dependencyResolutionManagement {
             library("compose-lifecycleViewModel", "androidx.lifecycle", "lifecycle-viewmodel-compose").versionRef("lifecycleViewModel")
             library("compose-activity", "androidx.activity:activity-compose:1.8.1")
 
-            library("compose-BOM", "androidx.compose:compose-bom:2024.01.00")
+            library("compose-BOM", "androidx.compose:compose-bom:2023.10.01")
             library("compose-androidMaterial3", "androidx.compose.material3", "material3").withoutVersion()
             library("compose-uiToolingPreview", "androidx.compose.ui", "ui-tooling-preview").withoutVersion()
             library("compose-uiViewBinding", "androidx.compose.ui", "ui-viewbinding").withoutVersion()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Using compose ProgressIndicator crashes the app since last compose BOM version.

Waiting for Google to release a new version fixing the issue

https://stackoverflow.com/a/77885753

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
