### PR TITLE
Fix/add missing chevron on filter chip

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/OceanFilterBar.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/OceanFilterBar.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -25,14 +24,16 @@ import br.com.useblu.oceands.model.Badge
 import br.com.useblu.oceands.model.OceanBadgeType
 import br.com.useblu.oceands.model.OceanBasicChip
 import br.com.useblu.oceands.model.OceanChip
+import br.com.useblu.oceands.model.OceanChipFilterOptions
 import br.com.useblu.oceands.model.OceanChipItemState
+import br.com.useblu.oceands.model.OceanFilterChip
 import br.com.useblu.oceands.utils.OceanIcons
 
 @Composable
 @Preview
 fun OceanFilterBarPreview() {
     OceanFilterBar(
-        filterList = listOf (
+        filterList = listOf(
             OceanBasicChip(
                 id = "0",
                 label = "Todos",
@@ -53,15 +54,12 @@ fun OceanFilterBarPreview() {
                 state = OceanChipItemState.INACTIVE_HOVER,
                 onClick = {},
             ),
-            OceanBasicChip(
+            OceanFilterChip(
                 id = "2",
                 label = "Canceladas",
-                badge = Badge(
-                    text = 2,
-                    type = OceanBadgeType.PRIMARY
-                ),
+                badge = null,
                 state = OceanChipItemState.INACTIVE_HOVER,
-                onClick = {},
+                filterOptions = OceanChipFilterOptions.SingleChoice("", emptyList(), {})
             ),
             OceanBasicChip(
                 id = "3",
@@ -72,7 +70,7 @@ fun OceanFilterBarPreview() {
                 ),
                 icon = OceanIcons.ADJUSTMENTS_OUTLINE,
                 state = OceanChipItemState.INACTIVE_HOVER,
-                onClick = {},
+                onClick = {}
             )
         )
     )
@@ -107,8 +105,8 @@ fun OceanFilterBar(
                         color = colorResource(R.color.ocean_color_interface_light_down)
                     )
                 }
-                OceanChip (
-                    model = itemModel,
+                OceanChip(
+                    model = itemModel
                 )
             }
         }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanChip.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanChip.kt
@@ -54,6 +54,20 @@ private fun OceanChipPreview() {
                 onPrimaryButtonClick = {},
                 onSecondaryButtonClick = {}
             )
+        ),
+        OceanFilterChip(
+            label = "Filtro Teste",
+            id = "9999",
+            badge = Badge(5, OceanBadgeType.PRIMARY_INVERTED),
+            state = OceanChipItemState.DEFAULT,
+            filterOptions = OceanChipFilterOptions.MultipleChoice(
+                title = "Status do Pagamento",
+                optionsItems = emptyList(),
+                primaryButtonLabel = "Salvar",
+                secondaryButtonLabel = "Limpar",
+                onPrimaryButtonClick = {},
+                onSecondaryButtonClick = {}
+            )
         )
     )
 
@@ -147,7 +161,7 @@ fun OceanFilterChip(
             .clickable {
                 model.filterOptions.showBottomSheet(context)
             }
-            .padding(horizontal = 12.dp),
+            .padding(start = 12.dp, end = 8.dp),
         verticalAlignment = CenterVertically
     ) {
         Text(
@@ -165,6 +179,14 @@ fun OceanFilterChip(
                 size = OceanBadgeSize.Small
             )
         }
+
+        OceanSpacing.StackXXXS()
+
+        OceanIcon(
+            iconType = OceanIcons.CHEVRON_DOWN_SOLID,
+            modifier = Modifier.size(16.dp),
+            tint = getContentColor(model)
+        )
     }
 }
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/header/OceanHeaderApp.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/header/OceanHeaderApp.kt
@@ -263,9 +263,9 @@ fun Header(
     ) {
         Column(
             modifier = Modifier
-                .clickable { model.onClickTitle() }
                 .weight(1f)
                 .padding(horizontal = 16.dp)
+                .clickable { model.onClickTitle() }
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanChip.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanChip.kt
@@ -18,7 +18,7 @@ data class OceanBasicChip(
     override val badge: Badge? = null,
     val icon: OceanIcons? = null,
     override var state: OceanChipItemState = OceanChipItemState.INACTIVE_HOVER,
-    var onClick: (selected: Boolean) -> Unit,
+    val onClick: (selected: Boolean) -> Unit,
     val hasFilterAll: Boolean = false,
 ): OceanChip()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the chevron icon at the end of the Row for Filter Chips

![image](https://github.com/ocean-ds/ocean-android/assets/15229294/700f3c3b-bc05-4860-9c3c-5941c5571255)
