### PR TITLE
fix: bottom sheets buttons order on horizontal orientation

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomSheet.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomSheet.kt
@@ -63,7 +63,7 @@ private fun OceanBottomSheetPreview() {
                             val coroutineScope = rememberCoroutineScope()
                             Column(Modifier.padding(vertical = 16.dp)) {
                                 Text(text = "Teste de bottom sheet")
-                                
+
                                 OceanRadioButton(label = "Testeeee")
 
                                 OceanButton(
@@ -374,12 +374,14 @@ private fun BottomButtons(
         return
     }
 
-    val buttons: @Composable (Modifier) -> Unit = {
-        val primaryStyle = if (isCritical) {
-            OceanButtonStyle.PrimaryCriticalMedium
-        } else OceanButtonStyle.PrimaryMedium
+    val buttons = mutableListOf<@Composable (Modifier) -> Unit>()
 
-        if (positiveButton != null) {
+    if (positiveButton != null) {
+        buttons.add {
+            val primaryStyle = if (isCritical) {
+                OceanButtonStyle.PrimaryCriticalMedium
+            } else OceanButtonStyle.PrimaryMedium
+
             OceanButton(
                 text = positiveButton.text,
                 buttonStyle = primaryStyle,
@@ -392,10 +394,10 @@ private fun BottomButtons(
                 modifier = it
             )
         }
+    }
 
-        if (negativeButton != null) {
-            OceanSpacing.StackXS()
-
+    if (negativeButton != null) {
+        buttons.add {
             OceanButton(
                 text = negativeButton.text,
                 icon = negativeButton.icon,
@@ -416,17 +418,23 @@ private fun BottomButtons(
     when (orientation) {
         BottomSheetButtonsOrientation.Horizontal -> {
             Row(
-                modifier = modifier
+                modifier = modifier,
+                horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
             ) {
-                buttons(Modifier.weight(1f))
+                buttons.reversed().forEach {
+                    it(Modifier.weight(1f))
+                }
             }
         }
 
         BottomSheetButtonsOrientation.Vertical -> {
             Column(
-                modifier = modifier
+                modifier = modifier,
+                verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
             ) {
-                buttons(Modifier.fillMaxWidth())
+                buttons.forEach {
+                    it(Modifier.fillMaxWidth())
+                }
             }
         }
     }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomSheet.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomSheet.kt
@@ -193,7 +193,8 @@ data class OceanBottomSheetModel(
     class Button(
         val text: String,
         val icon: OceanIcons? = null,
-        val onClick: () -> Unit
+        val onClick: () -> Unit,
+        val isDisabled: Boolean = false
     )
 }
 
@@ -391,7 +392,8 @@ private fun BottomButtons(
                         positiveButton.onClick.invoke()
                     }
                 },
-                modifier = it
+                modifier = it,
+                disabled = positiveButton.isDisabled
             )
         }
     }
@@ -407,7 +409,8 @@ private fun BottomButtons(
                         negativeButton.onClick.invoke()
                     }
                 },
-                modifier = it
+                modifier = it,
+                disabled = negativeButton.isDisabled
             )
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using Horizontal orientation for OceanBottomSheet, the positive action button was on the left. The expected is for it to be on the right.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

Horizontal orientation:

<img width="352" alt="image" src="https://github.com/ocean-ds/ocean-android/assets/168438425/7f5f428f-1f3a-4509-98b7-8bd582161d76">

Vertical orientation:

<img width="350" alt="image" src="https://github.com/ocean-ds/ocean-android/assets/168438425/1eae7e00-ad8c-48cf-a60c-6dd9230b6369">

