### PR TITLE
fix: apply max length correctly and add test

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/ui/compose/stringmask/OceanInputType.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/ui/compose/stringmask/OceanInputType.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import br.com.concrete.canarinho.formatador.Formatador
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanFontFamily
 import java.math.BigDecimal
@@ -123,6 +122,7 @@ sealed interface OceanInputType {
         override fun getKeyboardType() = KeyboardType.Number
 
         override fun transformForInput(text: String) = sanitizeWithDigits(text)
+        override fun transformForOutput(text: String) = sanitizeWithDigits(text)
 
         override fun getVisualTransformation(): VisualTransformation {
             return StaticMaskVisualTransformation {
@@ -143,8 +143,8 @@ sealed interface OceanInputType {
 
         override fun getKeyboardType() = KeyboardType.Number
 
-        private fun isNineDigits(e: String): Boolean {
-            return Formatador.Padroes.PADRAO_SOMENTE_NUMEROS.matcher(e).replaceAll("").length > 10
+        private fun isNineDigits(text: String): Boolean {
+            return text.filter { it.isDigit() }.length > 10
         }
 
         override fun transformForInput(text: String) = sanitizeWithDigits(text)
@@ -223,7 +223,7 @@ sealed interface OceanInputType {
         override fun transformForInput(text: String) = sanitizeWithDigits(text)
 
         override fun transformForOutput(text: String): String {
-            val digitsText = text.filter { it.isDigit() }.take(10)
+            val digitsText = text.filter { it.isDigit() }.take(8)
 
             if (digitsText.length <= 2) return text
 

--- a/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
@@ -30,7 +30,7 @@ class OceanTextInputTest {
 
         composeTestRule.onNode(isFocusable()).run {
             performTextInput("1")
-            this.assert(hasText("0,011"))
+            this.assert(hasText("0,01"))
             performTextInput("2")
             this.assert(hasText("0,12"))
             performKeyPress(

--- a/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
@@ -73,9 +73,57 @@ class OceanTextInputTest {
             this.assert(hasText("12345-36"))
             performTextInput("4")
             this.assert(hasText("12345-346"))
+            performKeyPress(
+                KeyEvent(
+                    NativeKeyEvent(
+                        NativeKeyEvent.ACTION_DOWN,
+                        NativeKeyEvent.KEYCODE_DPAD_RIGHT
+                    )
+                )
+            )
+            performTextInput("4")
+            this.assert(hasText("12345-346"))
         }
 
         Assert.assertEquals("12345346", inputText.value)
+    }
+
+    @Test
+    fun testPhoneType() {
+        setupComposeContent(OceanInputType.Phone)
+
+        composeTestRule.onNode(isFocusable()).run {
+            performTextInput("121")
+            this.assert(hasText("(12) 1"))
+            performTextInput("2345678")
+            this.assert(hasText("(12) 1234-5678"))
+            performTextInput("9")
+            this.assert(hasText("(12) 12345-6789"))
+            performTextInput("2")
+            this.assert(hasText("(12) 12345-6789"))
+        }
+
+        Assert.assertEquals("12123456789", inputText.value)
+    }
+
+    @Test
+    fun testDateType() {
+        setupComposeContent(OceanInputType.Date)
+
+        composeTestRule.onNode(isFocusable()).run {
+            performTextInput("12")
+            this.assert(hasText("12"))
+            performTextInput("1")
+            this.assert(hasText("12/1"))
+            performTextInput("2")
+            this.assert(hasText("12/12"))
+            performTextInput("2000")
+            this.assert(hasText("12/12/2000"))
+            performTextInput("2")
+            this.assert(hasText("12/12/2000"))
+        }
+
+        Assert.assertEquals("12/12/2000", inputText.value)
     }
 
     private fun setupComposeContent(

--- a/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/input/OceanTextInputTest.kt
@@ -30,7 +30,7 @@ class OceanTextInputTest {
 
         composeTestRule.onNode(isFocusable()).run {
             performTextInput("1")
-            this.assert(hasText("0,01"))
+            this.assert(hasText("0,011"))
             performTextInput("2")
             this.assert(hasText("0,12"))
             performKeyPress(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- CEP input was not sanitizing before sending the text to the callback event
- Date input had 10 numbers of max length, instead of 8


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

