### PR TITLE
feat: add OceanTag to OceanShortcut

### DIFF
--- a/.github/workflows/baselineprofile.yml
+++ b/.github/workflows/baselineprofile.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Generate baseline profiles
         run: |
           ./gradlew cleanManagedDevices --unused-only
-          ./gradlew clean :ocean-components:generateBaselineProfile -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 -Dorg.gradle.workers.max=4
+          ./gradlew :ocean-components:generateBaselineProfile -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect" -Pandroid.testInstrumentationRunnerArguments.androidx.benchmark.enabledRules=BaselineProfile -Pandroid.experimental.testOptions.managedDevices.setupTimeoutMinutes=20 -Dorg.gradle.workers.max=4
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.android.build.api.dsl.ManagedVirtualDevice
+import com.android.build.gradle.internal.dsl.ManagedVirtualDevice
 
 plugins {
     id("com.android.test")
@@ -11,12 +11,12 @@ android {
     compileSdk = 34
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     defaultConfig {
@@ -29,11 +29,11 @@ android {
     targetProjectPath = ":app"
 
     testOptions.managedDevices.devices {
-        create<ManagedVirtualDevice>("pixel7Api30") {
+        add(ManagedVirtualDevice("pixel7Api30").apply {
             device = "Pixel 7"
             apiLevel = 30
             systemImageSource = "aosp"
-        }
+        })
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "8.3.2"
+gradle = "8.3.0"
 junitVersion = "4.13.2"
 kotlinGradlePlugin = "2.0.0"
 benchmarkBaselineProfileGradlePlugin = "1.2.4"

--- a/ocean-components/src/main/java/br/com/useblu/oceands/bindingadapters/BindAdapterBadge.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/bindingadapters/BindAdapterBadge.kt
@@ -26,7 +26,6 @@ fun setBadgeType(view: View, badgeType: OceanBadgeType?) {
         OceanBadgeType.PRIMARY_INVERTED -> R.drawable.ocean_badge_primary_inverted
         OceanBadgeType.WARNING -> R.drawable.ocean_badge_warning
         OceanBadgeType.DISABLED -> R.drawable.ocean_badge_disabled
-        OceanBadgeType.CHIP_HOVER -> R.drawable.ocean_badge_primary_inverted
         null -> R.drawable.ocean_badge_highlight
     }
     view.background = ContextCompat.getDrawable(view.context, background)

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBadge.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBadge.kt
@@ -86,7 +86,6 @@ fun OceanBadge(
         OceanBadgeType.PRIMARY_INVERTED -> OceanColors.interfaceLightPure
         OceanBadgeType.WARNING -> OceanColors.statusWarningDeep
         OceanBadgeType.DISABLED -> OceanColors.interfaceDarkUp
-        OceanBadgeType.CHIP_HOVER -> OceanColors.interfaceLightPure
     }
 
     val formattedText = text.toIntOrNull()?.let {

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanShortcut.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanShortcut.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import br.com.useblu.oceands.model.OceanBadgeType
+import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.ui.compose.OceanTextStyle
@@ -36,14 +37,12 @@ fun OceanShortcutPreview() {
             label = "TinyVertical",
             icon = OceanIcons.ACADEMIC_CAP_SOLID,
             action = {},
-            badgeType = OceanBadgeType.HIGHLIGHT,
-            count = "Novo"
+            tag = OceanShortcutTag("Novo", OceanTagType.Important)
         ),
         OceanShortcutModel(
             label = "TinyVertical",
             icon = OceanIcons.ACADEMIC_CAP_SOLID,
-            badgeType = OceanBadgeType.WARNING,
-            count = "120"
+            badge = OceanShortcutBadge(count = 120, type = OceanBadgeType.WARNING)
         ),
 
         OceanShortcutModel(
@@ -73,15 +72,13 @@ fun OceanShortcutPreview() {
             label = "Small",
             icon = OceanIcons.ACADEMIC_CAP_SOLID,
             layout = OceanShortcutLayout.Small,
-            badgeType = OceanBadgeType.WARNING,
-            count = "120"
+            badge = OceanShortcutBadge(count = 120, type = OceanBadgeType.WARNING)
         ),
         OceanShortcutModel(
             label = "Small",
             icon = OceanIcons.ACADEMIC_CAP_SOLID,
             layout = OceanShortcutLayout.Small,
-            badgeType = OceanBadgeType.HIGHLIGHT,
-            count = "Novo"
+            tag = OceanShortcutTag("Novo", OceanTagType.Highlight)
         ),
 
         OceanShortcutModel(
@@ -171,8 +168,8 @@ fun OceanShortcut(
         icon = model.icon,
         modifier = modifier,
         description = model.description,
-        count = model.count,
-        badgeType = model.badgeType,
+        badge = model.badge,
+        tag = model.tag,
         action = model.action,
         layout = model.layout,
         blocked = model.blocked,
@@ -180,14 +177,24 @@ fun OceanShortcut(
     )
 }
 
+data class OceanShortcutBadge(
+    val count: Int,
+    val type: OceanBadgeType
+)
+
+data class OceanShortcutTag(
+    val text: String,
+    val type: OceanTagType
+)
+
 @Composable
 fun OceanShortcut(
     label: String,
     icon: OceanIcons,
     modifier: Modifier = Modifier,
     description: String? = null,
-    count: String? = null,
-    badgeType: OceanBadgeType? = null,
+    badge: OceanShortcutBadge? = null,
+    tag: OceanShortcutTag? = null,
     action: (() -> Unit)? = null,
     layout: OceanShortcutLayout = OceanShortcutLayout.TinyVertical,
     blocked: Boolean = false,
@@ -237,15 +244,27 @@ fun OceanShortcut(
                 )
             }
 
-            if (count != null && badgeType != null) {
-                OceanBadge(
-                    text = count,
-                    type = badgeType,
-                    size = OceanBadgeSize.Small,
-                    modifier = Modifier
-                        .padding(top = OceanSpacing.xxs, end = OceanSpacing.xxs)
-                        .align(Alignment.TopEnd)
-                )
+            when {
+                tag != null ->  {
+                    OceanTag(
+                        label = tag.text,
+                        type = tag.type,
+                        isSmall = true,
+                        modifier = Modifier
+                            .padding(top = OceanSpacing.xxs, end = OceanSpacing.xxs)
+                            .align(Alignment.TopEnd)
+                    )
+                }
+                badge != null -> {
+                    OceanBadge(
+                        text = badge.count.toString(),
+                        type = badge.type,
+                        size = OceanBadgeSize.Small,
+                        modifier = Modifier
+                            .padding(top = OceanSpacing.xxs, end = OceanSpacing.xxs)
+                            .align(Alignment.TopEnd)
+                    )
+                }
             }
 
             Column(
@@ -336,8 +355,8 @@ data class OceanShortcutModel(
     val label: String,
     val description: String? = null,
     val icon: OceanIcons,
-    val count: String? = null,
-    val badgeType: OceanBadgeType? = null,
+    val badge: OceanShortcutBadge? = null,
+    val tag: OceanShortcutTag? = null,
     val action: (() -> Unit)? = null,
     val layout: OceanShortcutLayout = OceanShortcutLayout.TinyVertical,
     val blocked: Boolean = false,

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTag.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTag.kt
@@ -1,13 +1,14 @@
 package br.com.useblu.oceands.components.compose
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,42 +26,37 @@ import br.com.useblu.oceands.utils.OceanIcons
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
 private fun OceanTagPreview() {
-    Row {
-        Column {
+    Row(
+        modifier = Modifier.padding(OceanSpacing.xxxs),
+        horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xxs)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(OceanSpacing.xxxs)
+        ) {
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Positive
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Warning
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Negative
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Complementary
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Neutral
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -68,16 +64,14 @@ private fun OceanTagPreview() {
             )
         }
 
-        OceanSpacing.StackXS()
-
-        Column {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(OceanSpacing.xxxs)
+        ) {
             OceanTag(
                 label = "Label",
                 icon = OceanIcons.LOCK_CLOSED_OUTLINE,
                 type = OceanTagType.Positive
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -85,15 +79,11 @@ private fun OceanTagPreview() {
                 type = OceanTagType.Warning
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 icon = OceanIcons.PLACEHOLDER_SOLID,
                 type = OceanTagType.Negative
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -101,15 +91,11 @@ private fun OceanTagPreview() {
                 type = OceanTagType.Complementary
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 icon = OceanIcons.PLACEHOLDER_SOLID,
                 type = OceanTagType.Neutral
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -118,16 +104,14 @@ private fun OceanTagPreview() {
             )
         }
 
-        OceanSpacing.StackXS()
-
-        Column {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(OceanSpacing.xxxs)
+        ) {
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Positive,
                 isSmall = true
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -135,15 +119,11 @@ private fun OceanTagPreview() {
                 isSmall = true
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Negative,
                 isSmall = true
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -151,15 +131,11 @@ private fun OceanTagPreview() {
                 isSmall = true
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Neutral,
                 isSmall = true
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -167,15 +143,11 @@ private fun OceanTagPreview() {
                 isSmall = true
             )
 
-            OceanSpacing.StackXXXS()
-
             OceanTag(
                 label = "Label",
                 type = OceanTagType.Important,
                 isSmall = true
             )
-
-            OceanSpacing.StackXXXS()
 
             OceanTag(
                 label = "Label",
@@ -188,6 +160,7 @@ private fun OceanTagPreview() {
 
 @Composable
 fun OceanTag(
+    modifier: Modifier = Modifier,
     label: String,
     type: OceanTagType,
     showIcon: Boolean = true,
@@ -199,16 +172,15 @@ fun OceanTag(
     val backgroundColor = getBackgroundColor(type = type)
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .background(
                 color = backgroundColor,
                 shape = RoundedCornerShape(16.dp)
             )
             .height(height),
         verticalAlignment = Alignment.CenterVertically
-
     ) {
-        if (showIcon) {
+        if (!isSmall && showIcon) {
             Spacer(modifier = Modifier.size(6.dp))
 
             val finalIcon = icon ?: getIconDefault(type)
@@ -220,13 +192,14 @@ fun OceanTag(
                     modifier = Modifier.size(16.dp)
                 )
             }
-        } else if (!isSmall) {
             OceanSpacing.StackXXXS()
         }
 
-        OceanSpacing.StackXXXS()
+        if (isSmall) {
+            OceanSpacing.StackXXXS()
+        }
 
-        Text(
+        OceanText(
             text = label,
             color = textColor,
             fontSize = if (isSmall) 10.sp else OceanFontSize.xxxs

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanBadgeType.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanBadgeType.kt
@@ -5,18 +5,16 @@ enum class OceanBadgeType {
     PRIMARY,
     PRIMARY_INVERTED,
     WARNING,
-    DISABLED,
-    CHIP_HOVER;
+    DISABLED;
 
     companion object {
         fun fromString(value: String): OceanBadgeType? {
             return when (value.lowercase()) {
                 "highlight" -> HIGHLIGHT
                 "primary" -> PRIMARY
-                "primaryinverted" -> PRIMARY_INVERTED
+                "primaryinverted", "chiphover" -> PRIMARY_INVERTED
                 "warning" -> WARNING
                 "disabled" -> DISABLED
-                "chiphover" -> CHIP_HOVER
                 else -> null
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Adds OceanTag parameter to OceanShortcut
- Fixes OceanTag spacings:

Before:
<img width="558" alt="image" src="https://github.com/user-attachments/assets/1b878a53-d95d-42f0-96de-4e37037bf135">

After:
<img width="479" alt="image" src="https://github.com/user-attachments/assets/d7cd022a-85f3-49c2-b874-135dc4650ef4">



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

