### PR TITLE
Add style Strikethrough in OceanSettingsListItem

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanContentList.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanContentList.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,7 +17,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import br.com.useblu.oceands.model.OceanSettingsStatus
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
@@ -27,7 +25,7 @@ import br.com.useblu.oceands.ui.compose.OceanTextStyle
 @Preview(
     showBackground = true,
     backgroundColor = 0xFFFFFFFF,
-    heightDp = 620
+    heightDp = 700
 )
 @Composable
 private fun OceanContentListPreview() {
@@ -95,12 +93,24 @@ private fun OceanContentListPreview() {
 
         OceanSpacing.StackXXS()
         OceanContentList(
+            style = ContentListStyle.Strikethrough(
+                title = "Title",
+                description = "Description",
+                newValue = "New Value",
+                caption = "Caption"
+            ),
+            isLoading = false
+        )
+
+        OceanSpacing.StackXXS()
+        OceanContentList(
             style = ContentListStyle.Inverted(
                 title = "Title",
-                description = "Description"
+                description = "Description",
             ),
             isLoading = true
         )
+
     }
 }
 
@@ -347,13 +357,6 @@ private fun StrikethroughContentList(
     style: ContentListStyle.Strikethrough,
     enabled: Boolean = true
 ) {
-
-    val isStrike = !style.newValue.isNullOrBlank()
-
-    val decoration = if (isStrike) {
-        TextDecoration.LineThrough
-    } else null
-
     Column(
         modifier = modifier.fillMaxWidth()
     ) {
@@ -371,13 +374,11 @@ private fun StrikethroughContentList(
             OceanText(
                 text = style.description,
                 style = OceanTextStyle.paragraph,
-                textDecoration = if (!style.newValue.isNullOrBlank()) {
-                    decoration
-                } else null,
+                textDecoration = if (style.newValue.isNotBlank()) TextDecoration.LineThrough else null,
                 color = OceanColors.interfaceDarkDown
             )
 
-            if (!style.newValue.isNullOrBlank()) {
+            if (style.newValue.isNotBlank()) {
                 OceanText(
                     modifier = Modifier.padding(start = OceanSpacing.xxxs),
                     text = style.newValue,
@@ -480,7 +481,7 @@ sealed interface ContentListStyle {
         val title: String,
         val description: String,
         val caption: String = "",
-        val newValue: String? = null
+        val newValue: String = ""
     ) : ContentListStyle
 }
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanContentList.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanContentList.kt
@@ -3,11 +3,14 @@ package br.com.useblu.oceands.components.compose
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,6 +18,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import br.com.useblu.oceands.model.OceanSettingsStatus
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
@@ -230,6 +234,12 @@ fun OceanContentList(
             style = style,
             enabled = enabled
         )
+
+        is ContentListStyle.Strikethrough -> StrikethroughContentList(
+            modifier = modifier,
+            style = style,
+            enabled = enabled
+        )
     }
 }
 
@@ -332,6 +342,63 @@ private fun InvertedContentList(
 }
 
 @Composable
+private fun StrikethroughContentList(
+    modifier: Modifier,
+    style: ContentListStyle.Strikethrough,
+    enabled: Boolean = true
+) {
+
+    val isStrike = !style.newValue.isNullOrBlank()
+
+    val decoration = if (isStrike) {
+        TextDecoration.LineThrough
+    } else null
+
+    Column(
+        modifier = modifier.fillMaxWidth()
+    ) {
+        OceanText(
+            text = style.title,
+            style = configTextStyle(
+                OceanTextStyle.description,
+                enabled
+            )
+        )
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OceanText(
+                text = style.description,
+                style = OceanTextStyle.paragraph,
+                textDecoration = if (!style.newValue.isNullOrBlank()) {
+                    decoration
+                } else null,
+                color = OceanColors.interfaceDarkDown
+            )
+
+            if (!style.newValue.isNullOrBlank()) {
+                OceanText(
+                    modifier = Modifier.padding(start = OceanSpacing.xxxs),
+                    text = style.newValue,
+                    style = OceanTextStyle.paragraph,
+                    color = OceanColors.statusPositiveDeep
+                )
+            }
+        }
+
+        if (style.caption.isNotBlank()) {
+            OceanText(
+                text = style.caption,
+                style = configTextStyle(OceanTextStyle.captionBold, enabled)
+            )
+        }
+
+        OceanSpacing.StackXXS()
+    }
+}
+
+@Composable
 private fun TransactionContentList(
     modifier: Modifier,
     style: ContentListTransactionStyle.Transaction,
@@ -407,6 +474,13 @@ sealed interface ContentListStyle {
         val title: String,
         val description: String,
         val caption: String = ""
+    ) : ContentListStyle
+
+    data class Strikethrough(
+        val title: String,
+        val description: String,
+        val caption: String = "",
+        val newValue: String? = null
     ) : ContentListStyle
 }
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanSettingsListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanSettingsListItem.kt
@@ -280,6 +280,21 @@ private fun SettingsListItemPreview() {
                 onClick = { println("Button Clicked") }
             ),
         )
+
+        OceanSettingsListItem(
+            style = SettingsListItemStyle.Button(
+                contentStyle = ContentListStyle.Strikethrough(
+                    title = "Taxa Promocional - Strikethrough",
+                    description = "11.06%",
+                    newValue = "7.33%",
+                ),
+                textError = "Error",
+                buttonText = "Entenda o cálculo",
+                buttonStyle = OceanButtonStyle.TertiarySmall,
+                onClick = { println("Button Clicked") }
+            ),
+        )
+        
         OceanSettingsListItem(
             style = SettingsListItemStyle.Button(
                 contentStyle = ContentListStyle.Inverted(

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanSettingsListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanSettingsListItem.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import br.com.useblu.oceands.extensions.compose.border
 import br.com.useblu.oceands.model.OceanSettingsStatus
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.ui.compose.OceanButtonStyle
@@ -255,6 +254,21 @@ private fun SettingsListItemPreview() {
                 onClick = { println("Button Clicked") }
             ),
         )
+
+        OceanSettingsListItem(
+            style = SettingsListItemStyle.Button(
+                contentStyle = ContentListStyle.Strikethrough(
+                    title = "Taxa Promocional - Strikethrough",
+                    description = "11.06%",
+                    newValue = "7.33%",
+                ),
+                textError = "Error",
+                buttonText = "Entenda o cálculo",
+                buttonStyle = OceanButtonStyle.TertiarySmall,
+                onClick = { println("Button Clicked") }
+            ),
+        )
+
         OceanSettingsListItem(
             style = SettingsListItemStyle.Button(
                 contentStyle = ContentListStyle.Default(
@@ -281,20 +295,7 @@ private fun SettingsListItemPreview() {
             ),
         )
 
-        OceanSettingsListItem(
-            style = SettingsListItemStyle.Button(
-                contentStyle = ContentListStyle.Strikethrough(
-                    title = "Taxa Promocional - Strikethrough",
-                    description = "11.06%",
-                    newValue = "7.33%",
-                ),
-                textError = "Error",
-                buttonText = "Entenda o cálculo",
-                buttonStyle = OceanButtonStyle.TertiarySmall,
-                onClick = { println("Button Clicked") }
-            ),
-        )
-        
+
         OceanSettingsListItem(
             style = SettingsListItemStyle.Button(
                 contentStyle = ContentListStyle.Inverted(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Essa PR adiciona o estilo Strikethrough no OceanSettingsListItem

Link do Figma:
https://www.figma.com/design/PgLv9k22CHHZZ867HwN65y/%F0%9F%8C%8A-Ocean-DS-Core?node-id=19347-74478&t=v3xVPpSzRrReLakY-4

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

<img width="381" alt="image" src="https://github.com/user-attachments/assets/c1191add-e3bf-4b01-ad61-62d12b838d3c">

