### PR TITLE
Fix: Expandable List Item spacings like anothers list items components

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/expandabletextlisticonitem/OceanExpandableTextListIconItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/expandabletextlisticonitem/OceanExpandableTextListIconItem.kt
@@ -36,6 +36,7 @@ import br.com.useblu.oceands.components.compose.OceanIcon
 import br.com.useblu.oceands.components.compose.OceanText
 import br.com.useblu.oceands.components.compose.expandabletextlisticonitem.model.OceanExpandableTextListIconItemChild
 import br.com.useblu.oceands.components.compose.expandabletextlisticonitem.model.OceanExpandableTextListIconItemChildType
+import br.com.useblu.oceands.extensions.compose.iconContainerBackground
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.ui.compose.OceanTextStyle
@@ -55,11 +56,13 @@ fun OceanExpandableTextListIconItemPreview() {
                 icon = OceanIcons.PLACEHOLDER_SOLID,
                 title = "Title",
                 collapsed = true,
+                showIconBackground = true,
                 childsItems = listOf(1, 2, 3).map {
                     OceanExpandableTextListIconItemChild(
                         icon = OceanIcons.PLACEHOLDER_SOLID,
                         title = "Title $it",
                         description = "Description $it",
+                        showIconBackground = true,
                         key = it
                     )
                 }
@@ -147,6 +150,7 @@ fun <ChildReferenceKey> OceanExpandableTextListIconItem(
     title: String,
     description: String?,
     collapsed: Boolean = true,
+    showIconBackground: Boolean = false,
     childs: OceanExpandableTextListIconItemChildType<ChildReferenceKey>,
     onClick: (OceanExpandableTextListIconItemChild<ChildReferenceKey>) -> Unit = {}
 ) {
@@ -163,6 +167,7 @@ fun <ChildReferenceKey> OceanExpandableTextListIconItem(
             title = title,
             description = description,
             collapsed = isCollapsed,
+            showIconBackground = showIconBackground
         )
         AnimatedVisibility(
             visible = isCollapsed.not()
@@ -182,6 +187,7 @@ private fun HeaderItem(
     icon: OceanIcons?,
     title: String,
     description: String?,
+    showIconBackground: Boolean,
     collapsed: Boolean
 ) {
     Row(
@@ -191,12 +197,21 @@ private fun HeaderItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         icon?.let {
-            OceanIcon(
+            Box(
                 modifier = Modifier
-                    .size(32.dp)
-                    .padding(end = OceanSpacing.xxs),
-                iconType = it
-            )
+                    .size(40.dp)
+                    .iconContainerBackground(showIconBackground)
+            ) {
+                OceanIcon(
+                    iconType = it,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(24.dp),
+                    tint = OceanColors.brandPrimaryDown
+                )
+            }
+
+            OceanSpacing.StackXS()
         }
 
         Column(
@@ -268,14 +283,22 @@ private fun <ChildReferenceKey>DefaultChildItem(
         verticalAlignment = Alignment.CenterVertically
     ) {
         item.icon?.let {
-            OceanIcon(
+            Box(
                 modifier = Modifier
-                    .size(28.dp)
-                    .padding(start = OceanSpacing.xxxs, end = OceanSpacing.xxs),
-                iconType = it
-
-            )
+                    .size(40.dp)
+                    .iconContainerBackground(item.showIconBackground)
+            ) {
+                OceanIcon(
+                    iconType = it,
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .size(20.dp),
+                    tint = OceanColors.brandPrimaryDown
+                )
+            }
         }
+
+        OceanSpacing.StackXS()
 
         Column(
             modifier = Modifier
@@ -308,7 +331,8 @@ private fun <ChildReferenceKey>DefaultChildItem(
                         onClick = { expanded = true }
                     ) {
                         OceanIcon(
-                            iconType = OceanIcons.DOTS_VERTICAL_SOLID
+                            iconType = OceanIcons.DOTS_VERTICAL_SOLID,
+                            tint = OceanColors.interfaceDarkUp,
                         )
                     }
 
@@ -341,7 +365,8 @@ private fun <ChildReferenceKey>DefaultChildItem(
                     OceanIcon(
                         modifier = Modifier
                             .padding(end = OceanSpacing.xs),
-                        iconType = it
+                        iconType = it,
+                        tint = OceanColors.interfaceDarkUp,
                     )
                 }
             }
@@ -358,17 +383,27 @@ private fun <ChildReferenceKey>WithSwipeChildItem(
         content = {
             Row(
                 modifier = Modifier
-                    .padding(start = OceanSpacing.sm, end = OceanSpacing.xxs)
+                    .padding(start = OceanSpacing.xs, end = OceanSpacing.xxs)
                     .padding(vertical = OceanSpacing.xs),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 item.icon?.let {
-                    OceanIcon(
+                    Box(
                         modifier = Modifier
-                            .padding(end = OceanSpacing.xxs),
-                        iconType = it
-                    )
+                            .size(40.dp)
+                            .iconContainerBackground(item.showIconBackground)
+                    ) {
+                        OceanIcon(
+                            iconType = it,
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .size(20.dp),
+                            tint = OceanColors.brandPrimaryDown
+                        )
+                    }
                 }
+
+                OceanSpacing.StackXS()
 
                 Column(
                     modifier = Modifier
@@ -397,6 +432,7 @@ private fun <ChildReferenceKey>WithSwipeChildItem(
                 Icon(
                     painter = painterResource(id = R.drawable.icon_swipe),
                     contentDescription = null,
+                    tint = OceanColors.interfaceDarkUp
                 )
             }
         },
@@ -413,16 +449,20 @@ fun <ChildReferenceKey> OceanExpandableTextListIconItem(
     title: String,
     description: String? = null,
     collapsed: Boolean = true,
+    showIconBackground: Boolean = false,
     childsItems: List<OceanExpandableTextListIconItemChild<ChildReferenceKey>>,
+    onClick: (OceanExpandableTextListIconItemChild<ChildReferenceKey>) -> Unit = {}
 ) {
     OceanExpandableTextListIconItem(
         icon = icon,
         title = title,
         description = description,
         collapsed = collapsed,
+        showIconBackground = showIconBackground,
         childs = OceanExpandableTextListIconItemChildType.Default(
             items = childsItems
-        )
+        ),
+        onClick = onClick
     )
 }
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/expandabletextlisticonitem/model/OceanExpandableTextListIconItemChild.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/expandabletextlisticonitem/model/OceanExpandableTextListIconItemChild.kt
@@ -4,6 +4,7 @@ import br.com.useblu.oceands.utils.OceanIcons
 
 data class OceanExpandableTextListIconItemChild<ReferenceKey>(
     val icon: OceanIcons?,
+    val showIconBackground: Boolean = false,
     val title: String,
     val description: String? = null,
     val key: ReferenceKey


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Spacing definitions is different of standard of another List Items components:
<img width="289" alt="Screenshot 2025-02-06 at 15 58 08" src="https://github.com/user-attachments/assets/04fb0365-ad5f-448f-8128-19bd37dd93f0" />

In this way, this will fix to make Expandable List Item with same spacings as another List Items to keep same experience.

Fix colors for tint icons

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

Actual:
<img width="423" alt="Screenshot 2025-02-06 at 16 27 59" src="https://github.com/user-attachments/assets/fcbe4c40-e89a-4ae1-a048-20c4117288d6" />

Reference:
<img width="414" alt="Screenshot 2025-02-06 at 16 28 21" src="https://github.com/user-attachments/assets/422994ba-7450-485c-a7f3-dba2233b392e" />

App example:

https://github.com/user-attachments/assets/d265b4e4-70e4-4d75-a436-2d7a2534909f



