### PR TITLE
Fix: adjust topbar alignment

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomNavigation.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanBottomNavigation.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import br.com.useblu.oceands.extensions.compose.height
 import br.com.useblu.oceands.model.compose.OceanBottomNavigationModel
 import br.com.useblu.oceands.model.compose.bottomnavigation.OceanBottomNavigationColorStyle
@@ -62,6 +61,22 @@ private val initialModelList = mutableStateOf(
             inactiveIcon = OceanIcons.PAGBLU_OUTLINE,
             onClickListener = {
                 selectedIndex.value = 1
+            }
+        ),
+        OceanBottomNavigationModel(
+            label = "Cobrar",
+            activeIcon = OceanIcons.CHARGE_SOLID,
+            inactiveIcon = OceanIcons.CHARGE_OUTLINE,
+            onClickListener = {
+                selectedIndex.value = 2
+            }
+        ),
+        OceanBottomNavigationModel(
+            label = "Cobrar",
+            activeIcon = OceanIcons.CHARGE_SOLID,
+            inactiveIcon = OceanIcons.CHARGE_OUTLINE,
+            onClickListener = {
+                selectedIndex.value = 2
             }
         ),
         OceanBottomNavigationModel(
@@ -108,10 +123,18 @@ private fun OceanBottomNavigationPreview() {
 
     Scaffold(
         bottomBar = {
-            OceanBottomNavigation(
-                selectedIndex = selectedIndex.value,
-                models = initialModelList.value
-            )
+            Column {
+                OceanBottomNavigation(
+                    selectedIndex = selectedIndex.value,
+                    models = initialModelList.value,
+                    spacingStyle = OceanBottomNavigationSpacingStyle.Compact,
+                    colorStyle = OceanBottomNavigationColorStyle.Inverse
+                )
+                OceanBottomNavigation(
+                    selectedIndex = selectedIndex.value,
+                    models = initialModelList.value
+                )
+            }
         }
     ) {
         it
@@ -204,9 +227,7 @@ private fun OceanBottomNavigationMenuItem(
 ) {
     val color = if (isSelected) colorStyle.itemSelected else colorStyle.item
     Column(
-        modifier = modifier
-            .padding(horizontal = OceanSpacing.xxsExtra)
-            .padding(vertical = OceanSpacing.xxxs),
+        modifier = spacingStyle.getModifier(modifier),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
@@ -225,7 +246,7 @@ private fun OceanBottomNavigationMenuItem(
             text = model.label,
             color = color,
             fontFamily = OceanFontFamily.HighlightExtraBold,
-            fontSize = 12.sp
+            fontSize = spacingStyle.fontSize
         )
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTopBarInverse.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTopBarInverse.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -205,7 +206,8 @@ private fun TopBar(
                 .heightIn(min = 56.dp, max = 92.dp)
                 .fillMaxWidth()
                 .wrapContentHeight()
-                .clickable { onClickToolbar() }
+                .clickable { onClickToolbar() },
+            verticalAlignment = Alignment.CenterVertically
         ) {
             val topBarIcon = icon ?: OceanIcons.ARROW_LEFT_OUTLINE
             val iconButtonSize = 56.dp

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/bottomnavigation/OceanBottomNavigationSpacingStyle.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/bottomnavigation/OceanBottomNavigationSpacingStyle.kt
@@ -1,10 +1,15 @@
 package br.com.useblu.oceands.model.compose.bottomnavigation
 
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import br.com.useblu.oceands.ui.compose.OceanSpacing
 
 sealed interface OceanBottomNavigationSpacingStyle {
     data object Default : OceanBottomNavigationSpacingStyle
@@ -41,4 +46,22 @@ sealed interface OceanBottomNavigationSpacingStyle {
                 is Compact -> 20.dp
             }
         }
+
+    @Composable
+    fun getModifier(modifier: Modifier): Modifier {
+        return when (this) {
+            is Default -> modifier.wrapContentHeight()
+            is Compact ->
+                modifier
+                    .padding(horizontal = OceanSpacing.xxsExtra)
+                    .padding(vertical = OceanSpacing.xxxs)
+        }
+    }
+
+    val fontSize: TextUnit
+        get() =
+            when (this) {
+                is Default -> 10.sp
+                is Compact -> 12.sp
+            }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

CenterVertically in OceanTopBar

Extra: fix legacy bottom navigation item height

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):
<img width="724" height="494" alt="Captura de Tela 2025-07-17 às 16 13 24" src="https://github.com/user-attachments/assets/4e6e86eb-dc99-4800-8410-3201035383a6" />

Extra: correção do bottomnavigation legado para não quebrar linha

<img width="366" height="785" alt="Captura de Tela 2025-07-17 às 16 45 59" src="https://github.com/user-attachments/assets/431b084a-f61f-4cc5-a49a-4b8c0b06dfc5" />


