### PR TITLE
feat: Replace simple space per Non-Breaking Space (\u00A0)

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/extensions/Extensions.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/extensions/Extensions.kt
@@ -44,7 +44,8 @@ fun Date.oceanFormat(pattern: String): String {
 
 fun Double.oceanFormatWithCurrency(): String {
     val final = BigDecimal(this).setScale(2, RoundingMode.HALF_EVEN)
-    return FormatTypes.FORMAT_VALUE_WITH_SYMBOL.format(final.toString())
+    val formatted = FormatTypes.FORMAT_VALUE_WITH_SYMBOL.format(final.toString())
+    return formatted.replaceFirst(" ", "\u00A0")
 }
 
 fun Long.oceanFormatWithCurrency(): String {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- \u00A0 é o código Unicode para Non-Breaking Space (espaço não-quebrável)
- Isso garante que "R$" e o valor sempre fiquem juntos na mesma linha
- O texto pode quebrar em outros pontos, mas nunca vai separar a moeda do valor

Exemplo: Se houver quebra de linha, ela vai acontecer antes do "R$ 1.234,56" inteiro, mantendo a moeda e o valor sempre unidos! 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

<img width="415" height="848" alt="image" src="https://github.com/user-attachments/assets/ef13d2d4-74cb-46d5-a6b3-75f613186214" />

