### PR TITLE
fix: increase snackbar vertical padding from 4dp to 16dp

### DIFF
--- a/ocean-components/src/main/res/drawable/ocean_snackbar_background.xml
+++ b/ocean-components/src/main/res/drawable/ocean_snackbar_background.xml
@@ -10,10 +10,10 @@
             <solid android:color="@color/ocean_color_interface_dark_deep" />
             <corners android:radius="@dimen/ocean_border_radius_sm" />
             <padding
-                android:bottom="@dimen/ocean_spacing_inline_xxxs"
+                android:bottom="@dimen/ocean_spacing_inline_xs"
                 android:left="@dimen/ocean_spacing_inline_sm"
                 android:right="@dimen/ocean_spacing_inline_xs"
-                android:top="@dimen/ocean_spacing_inline_xxxs" />
+                android:top="@dimen/ocean_spacing_inline_xs" />
         </shape>
     </item>
 </layer-list>


### PR DESCRIPTION
## Summary
- Increased vertical padding in `ocean_snackbar_background.xml` from `ocean_spacing_inline_xxxs` (4dp) to `ocean_spacing_inline_xs` (16dp)
- The previous 4dp padding caused the snackbar text to appear visually cramped with no vertical breathing room

## Test plan
- [x] Verify snackbar appearance on screens that use `OceanSnackBar` (e.g. `SmsCodeConfirmationFragment`)
- [x] Confirm vertical padding is visually consistent (16dp top/bottom)

## Screenshot

<img width="424" height="906" alt="Screenshot 2026-04-16 at 14 01 05" src="https://github.com/user-attachments/assets/2fec8b42-4505-489a-a8c5-1b92d2ef4570" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)