### PR TITLE
feat(text-list-read-only): add OceanTextListReadOnly composite

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -82,6 +82,7 @@
         <activity android:name=".ui.cardreadonly.CardReadOnlyActivity" />
         <activity android:name=".ui.cardlistexpandable.OceanCardListExpandableActivity" />
         <activity android:name=".ui.textlistaction.OceanTextListActionActivity" />
+        <activity android:name=".ui.textlistreadonly.TextListReadOnlyActivity" />
         <activity android:name=".ui.cardbalance.CardBalanceActivity" />
         <activity android:name=".ui.cardoption.CardOptionActivity" />
         <activity android:name=".ui.banner.BannerActivity" />

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
@@ -83,6 +83,7 @@ import br.com.useblu.oceands.client.ui.textlisticonitem.TextListIconItemActivity
 import br.com.useblu.oceands.client.ui.textlistinline.TextListInlineItemActivity
 import br.com.useblu.oceands.client.ui.textlistinverted.TextListInvertedItemActivity
 import br.com.useblu.oceands.client.ui.textlistitem.TextListItemActivity
+import br.com.useblu.oceands.client.ui.textlistreadonly.TextListReadOnlyActivity
 import br.com.useblu.oceands.client.ui.tokeninput.TokenInputActivity
 import br.com.useblu.oceands.client.ui.toobar.TopbarActivity
 import br.com.useblu.oceands.client.ui.transactionfooter.TransactionFooterActivity
@@ -238,6 +239,7 @@ class HomeActivity : AppCompatActivity() {
                         textAction(text = "Text List Inline Item", onClick = { textListInlineItem() })
                         textAction(text = "Text List Inverted Item", onClick = { textListInvertedItem() })
                         textAction(text = "Text List Item", onClick = { textListItem() })
+                        textAction(text = "Text List Read Only", onClick = { textListReadOnly() })
                         textAction(text = "Text List Settings", onClick = { listItemsSettings() })
                         textAction(text = "Toast", onClick = { onClickToast() })
                         textAction(text = "Token Input", onClick = { onClickTokenInput() })
@@ -431,6 +433,11 @@ class HomeActivity : AppCompatActivity() {
 
     private fun textListInvertedItem() {
         val intent = Intent(this, TextListInvertedItemActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun textListReadOnly() {
+        val intent = Intent(this, TextListReadOnlyActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/textlistreadonly/TextListReadOnlyActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/textlistreadonly/TextListReadOnlyActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -12,13 +11,9 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import br.com.useblu.oceands.components.compose.OceanTextNotBlank
 import br.com.useblu.oceands.components.compose.OceanTheme
-import br.com.useblu.oceands.components.compose.textlistreadonly.OceanTextListReadOnlyDefaultPreview
-import br.com.useblu.oceands.components.compose.textlistreadonly.OceanTextListReadOnlyInvertedPreview
+import br.com.useblu.oceands.components.compose.textlistreadonly.OceanTextListReadOnlyPreview
 import br.com.useblu.oceands.ui.compose.OceanColors
-import br.com.useblu.oceands.ui.compose.OceanSpacing
-import br.com.useblu.oceands.ui.compose.OceanTextStyle
 
 class TextListReadOnlyActivity : AppCompatActivity() {
 
@@ -32,27 +27,9 @@ class TextListReadOnlyActivity : AppCompatActivity() {
                             .fillMaxSize()
                             .background(OceanColors.interfaceLightPure)
                             .padding(padding)
-                            .verticalScroll(rememberScrollState()),
-                        verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
+                            .verticalScroll(rememberScrollState())
                     ) {
-                        OceanTextNotBlank(
-                            text = "Inverted variants",
-                            modifier = Modifier.padding(
-                                start = OceanSpacing.xs,
-                                top = OceanSpacing.xs
-                            ),
-                            style = OceanTextStyle.heading4,
-                            color = OceanColors.interfaceDarkDeep
-                        )
-                        OceanTextListReadOnlyInvertedPreview()
-
-                        OceanTextNotBlank(
-                            text = "States (Default / Disabled / Loading)",
-                            modifier = Modifier.padding(start = OceanSpacing.xs),
-                            style = OceanTextStyle.heading4,
-                            color = OceanColors.interfaceDarkDeep
-                        )
-                        OceanTextListReadOnlyDefaultPreview()
+                        OceanTextListReadOnlyPreview()
                     }
                 }
             }

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/textlistreadonly/TextListReadOnlyActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/textlistreadonly/TextListReadOnlyActivity.kt
@@ -1,0 +1,61 @@
+package br.com.useblu.oceands.client.ui.textlistreadonly
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
+import br.com.useblu.oceands.components.compose.OceanTextNotBlank
+import br.com.useblu.oceands.components.compose.OceanTheme
+import br.com.useblu.oceands.components.compose.textlistreadonly.OceanTextListReadOnlyDefaultPreview
+import br.com.useblu.oceands.components.compose.textlistreadonly.OceanTextListReadOnlyInvertedPreview
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanSpacing
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
+
+class TextListReadOnlyActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            OceanTheme {
+                Scaffold { padding ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(OceanColors.interfaceLightPure)
+                            .padding(padding)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
+                    ) {
+                        OceanTextNotBlank(
+                            text = "Inverted variants",
+                            modifier = Modifier.padding(
+                                start = OceanSpacing.xs,
+                                top = OceanSpacing.xs
+                            ),
+                            style = OceanTextStyle.heading4,
+                            color = OceanColors.interfaceDarkDeep
+                        )
+                        OceanTextListReadOnlyInvertedPreview()
+
+                        OceanTextNotBlank(
+                            text = "States (Default / Disabled / Loading)",
+                            modifier = Modifier.padding(start = OceanSpacing.xs),
+                            style = OceanTextStyle.heading4,
+                            color = OceanColors.interfaceDarkDeep
+                        )
+                        OceanTextListReadOnlyDefaultPreview()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
@@ -84,7 +84,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
         modifier = Modifier.background(OceanColors.interfaceLightPure),
         verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
     ) {
-        // highlightLead + inverted — Blu balance header
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Inverted(
                 title = "Saldo total na Blu",
@@ -93,7 +92,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             )
         )
 
-        // default with caption
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
@@ -102,7 +100,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             )
         )
 
-        // highlight + tag
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Inverted(
                 title = "Title",
@@ -116,7 +113,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             )
         )
 
-        // default with leading icon + divider
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
@@ -129,7 +125,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             showDivider = true
         )
 
-        // disabled
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
@@ -139,7 +134,6 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             state = OceanTextListReadOnlyState.Disabled
         )
 
-        // loading
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
@@ -1,0 +1,177 @@
+package br.com.useblu.oceands.components.compose.textlistreadonly
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import br.com.useblu.oceands.components.compose.ContentListStyle
+import br.com.useblu.oceands.components.compose.OceanContentList
+import br.com.useblu.oceands.components.compose.OceanDivider
+import br.com.useblu.oceands.components.compose.OceanIcon
+import br.com.useblu.oceands.components.compose.OceanTag
+import br.com.useblu.oceands.components.compose.OceanTagLayout
+import br.com.useblu.oceands.components.compose.OceanTagStyle
+import br.com.useblu.oceands.components.compose.OceanTheme
+import br.com.useblu.oceands.model.OceanTagType
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanSpacing
+import br.com.useblu.oceands.utils.OceanIcons
+
+enum class OceanTextListReadOnlyState {
+    Default,
+    Disabled,
+    Loading
+}
+
+@Composable
+fun OceanTextListReadOnly(
+    modifier: Modifier = Modifier,
+    contentListStyle: ContentListStyle,
+    state: OceanTextListReadOnlyState = OceanTextListReadOnlyState.Default,
+    showIcon: Boolean = false,
+    icon: OceanIcons? = null,
+    iconTint: Color = OceanColors.interfaceDarkUp,
+    iconSize: Dp? = null,
+    showIndicator: Boolean = false,
+    indicator: OceanTagStyle? = null,
+    indicatorLayout: OceanTagLayout = OceanTagLayout.Medium(),
+    showDivider: Boolean = false
+) {
+    val enabled = state != OceanTextListReadOnlyState.Disabled
+    val isLoading = state == OceanTextListReadOnlyState.Loading
+
+    Column(
+        modifier = modifier.background(OceanColors.interfaceLightPure)
+    ) {
+        Row(
+            modifier = Modifier.padding(OceanSpacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xxs)
+        ) {
+            if (showIcon && icon != null) {
+                val iconModifier = iconSize?.let { Modifier.size(it) } ?: Modifier
+                OceanIcon(
+                    iconType = icon,
+                    modifier = iconModifier,
+                    tint = if (enabled) iconTint else OceanColors.interfaceDarkUp
+                )
+            }
+
+            OceanContentList(
+                modifier = Modifier.weight(1f),
+                style = contentListStyle,
+                isLoading = isLoading,
+                enabled = enabled
+            )
+
+            if (showIndicator && indicator != null && !isLoading) {
+                OceanTag(
+                    style = indicator,
+                    enabled = enabled
+                )
+            }
+        }
+
+        if (showDivider) {
+            OceanDivider(
+                modifier = Modifier.padding(horizontal = OceanSpacing.xs)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun OceanTextListReadOnlyInvertedPreview() = OceanTheme {
+    Column(
+        modifier = Modifier.background(OceanColors.interfaceLightPure)
+    ) {
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Saldo total na Blu",
+                description = "R$ 2.500,00"
+            )
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Saldo total na Blu",
+                description = "R$ 2.500,00"
+            ),
+            showDivider = true
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Saldo total na Blu",
+                description = "R$ 2.500,00"
+            ),
+            showIcon = true,
+            icon = OceanIcons.INFORMATION_CIRCLE_OUTLINE
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Saldo total na Blu",
+                description = "R$ 2.500,00"
+            ),
+            showIndicator = true,
+            indicator = OceanTagStyle.Default(
+                label = "Ativo",
+                layout = OceanTagLayout.Medium(),
+                type = OceanTagType.Positive
+            )
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Saldo total na Blu",
+                description = "R$ 2.500,00",
+                caption = "Atualizado agora"
+            ),
+            showIcon = true,
+            icon = OceanIcons.INFORMATION_CIRCLE_OUTLINE,
+            showIndicator = true,
+            indicator = OceanTagStyle.Default(
+                label = "Novo",
+                layout = OceanTagLayout.Medium(),
+                type = OceanTagType.Complementary
+            ),
+            showDivider = true
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Composable
+private fun OceanTextListReadOnlyDefaultPreview() = OceanTheme {
+    Column(
+        modifier = Modifier.background(OceanColors.interfaceLightPure)
+    ) {
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Default(
+                title = "Title",
+                description = "Description",
+                caption = "Caption"
+            )
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Default(
+                title = "Title",
+                description = "Description"
+            ),
+            state = OceanTextListReadOnlyState.Disabled
+        )
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Default(
+                title = "Title",
+                description = "Description"
+            ),
+            state = OceanTextListReadOnlyState.Loading
+        )
+    }
+}

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
@@ -23,6 +23,7 @@ import br.com.useblu.oceands.components.compose.OceanTheme
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
 import br.com.useblu.oceands.utils.OceanIcons
 
 enum class OceanTextListReadOnlyState {
@@ -88,70 +89,23 @@ fun OceanTextListReadOnly(
     }
 }
 
-@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
+@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF, heightDp = 900)
 @Composable
-fun OceanTextListReadOnlyInvertedPreview() = OceanTheme {
+fun OceanTextListReadOnlyPreview() = OceanTheme {
     Column(
-        modifier = Modifier.background(OceanColors.interfaceLightPure)
+        modifier = Modifier.background(OceanColors.interfaceLightPure),
+        verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
     ) {
-        OceanTextListReadOnly(
-            contentListStyle = ContentListStyle.Inverted(
-                title = "Saldo total na Blu",
-                description = "R$ 2.500,00"
-            )
-        )
-        OceanTextListReadOnly(
-            contentListStyle = ContentListStyle.Inverted(
-                title = "Saldo total na Blu",
-                description = "R$ 2.500,00"
-            ),
-            showDivider = true
-        )
-        OceanTextListReadOnly(
-            contentListStyle = ContentListStyle.Inverted(
-                title = "Saldo total na Blu",
-                description = "R$ 2.500,00"
-            ),
-            showIcon = true,
-            icon = OceanIcons.INFORMATION_CIRCLE_OUTLINE
-        )
-        OceanTextListReadOnly(
-            contentListStyle = ContentListStyle.Inverted(
-                title = "Saldo total na Blu",
-                description = "R$ 2.500,00"
-            ),
-            showIndicator = true,
-            indicator = OceanTagStyle.Default(
-                label = "Ativo",
-                layout = OceanTagLayout.Medium(),
-                type = OceanTagType.Positive
-            )
-        )
+        // highlightLead + inverted — Blu balance header
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Inverted(
                 title = "Saldo total na Blu",
                 description = "R$ 2.500,00",
-                caption = "Atualizado agora"
-            ),
-            showIcon = true,
-            icon = OceanIcons.INFORMATION_CIRCLE_OUTLINE,
-            showIndicator = true,
-            indicator = OceanTagStyle.Default(
-                label = "Novo",
-                layout = OceanTagLayout.Medium(),
-                type = OceanTagType.Complementary
-            ),
-            showDivider = true
+                descriptionStyle = OceanTextStyle.lead
+            )
         )
-    }
-}
 
-@Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
-@Composable
-fun OceanTextListReadOnlyDefaultPreview() = OceanTheme {
-    Column(
-        modifier = Modifier.background(OceanColors.interfaceLightPure)
-    ) {
+        // default with caption
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
@@ -159,13 +113,44 @@ fun OceanTextListReadOnlyDefaultPreview() = OceanTheme {
                 caption = "Caption"
             )
         )
+
+        // highlight + tag indicator
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Inverted(
+                title = "Title",
+                description = "Description",
+                descriptionStyle = OceanTextStyle.lead
+            ),
+            showIndicator = true,
+            indicator = OceanTagStyle.Highlight(
+                label = "Novo",
+                type = OceanTagType.Highlight,
+                layout = OceanTagLayout.Small()
+            )
+        )
+
+        // default with icon + divider
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
                 description = "Description"
             ),
+            showIcon = true,
+            icon = OceanIcons.PLACEHOLDER_SOLID,
+            showDivider = true
+        )
+
+        // disabled
+        OceanTextListReadOnly(
+            contentListStyle = ContentListStyle.Default(
+                title = "Title",
+                description = "Description",
+                caption = "Caption"
+            ),
             state = OceanTextListReadOnlyState.Disabled
         )
+
+        // loading
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
@@ -90,7 +90,7 @@ fun OceanTextListReadOnly(
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
-private fun OceanTextListReadOnlyInvertedPreview() = OceanTheme {
+fun OceanTextListReadOnlyInvertedPreview() = OceanTheme {
     Column(
         modifier = Modifier.background(OceanColors.interfaceLightPure)
     ) {
@@ -148,7 +148,7 @@ private fun OceanTextListReadOnlyInvertedPreview() = OceanTheme {
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFFFF)
 @Composable
-private fun OceanTextListReadOnlyDefaultPreview() = OceanTheme {
+fun OceanTextListReadOnlyDefaultPreview() = OceanTheme {
     Column(
         modifier = Modifier.background(OceanColors.interfaceLightPure)
     ) {

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import br.com.useblu.oceands.components.compose.ContentListStyle
 import br.com.useblu.oceands.components.compose.OceanContentList
 import br.com.useblu.oceands.components.compose.OceanDivider
@@ -21,29 +19,20 @@ import br.com.useblu.oceands.components.compose.OceanTagLayout
 import br.com.useblu.oceands.components.compose.OceanTagStyle
 import br.com.useblu.oceands.components.compose.OceanTheme
 import br.com.useblu.oceands.model.OceanTagType
+import br.com.useblu.oceands.model.compose.OceanIconModel
+import br.com.useblu.oceands.model.compose.OceanTextListReadOnlyState
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.ui.compose.OceanTextStyle
 import br.com.useblu.oceands.utils.OceanIcons
-
-enum class OceanTextListReadOnlyState {
-    Default,
-    Disabled,
-    Loading
-}
 
 @Composable
 fun OceanTextListReadOnly(
     modifier: Modifier = Modifier,
     contentListStyle: ContentListStyle,
     state: OceanTextListReadOnlyState = OceanTextListReadOnlyState.Default,
-    showIcon: Boolean = false,
-    icon: OceanIcons? = null,
-    iconTint: Color = OceanColors.interfaceDarkUp,
-    iconSize: Dp? = null,
-    showIndicator: Boolean = false,
-    indicator: OceanTagStyle? = null,
-    indicatorLayout: OceanTagLayout = OceanTagLayout.Medium(),
+    icon: OceanIconModel? = null,
+    tag: OceanTagStyle? = null,
     showDivider: Boolean = false
 ) {
     val enabled = state != OceanTextListReadOnlyState.Disabled
@@ -57,12 +46,11 @@ fun OceanTextListReadOnly(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xxs)
         ) {
-            if (showIcon && icon != null) {
-                val iconModifier = iconSize?.let { Modifier.size(it) } ?: Modifier
+            icon?.let {
                 OceanIcon(
-                    iconType = icon,
-                    modifier = iconModifier,
-                    tint = if (enabled) iconTint else OceanColors.interfaceDarkUp
+                    iconType = it.icon,
+                    modifier = it.size?.let { size -> Modifier.size(size) } ?: Modifier,
+                    tint = it.tint
                 )
             }
 
@@ -73,9 +61,9 @@ fun OceanTextListReadOnly(
                 enabled = enabled
             )
 
-            if (showIndicator && indicator != null && !isLoading) {
+            tag?.takeIf { !isLoading }?.let {
                 OceanTag(
-                    style = indicator,
+                    style = it,
                     enabled = enabled
                 )
             }
@@ -114,29 +102,30 @@ fun OceanTextListReadOnlyPreview() = OceanTheme {
             )
         )
 
-        // highlight + tag indicator
+        // highlight + tag
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Inverted(
                 title = "Title",
                 description = "Description",
                 descriptionStyle = OceanTextStyle.lead
             ),
-            showIndicator = true,
-            indicator = OceanTagStyle.Highlight(
+            tag = OceanTagStyle.Highlight(
                 label = "Novo",
                 type = OceanTagType.Highlight,
                 layout = OceanTagLayout.Small()
             )
         )
 
-        // default with icon + divider
+        // default with leading icon + divider
         OceanTextListReadOnly(
             contentListStyle = ContentListStyle.Default(
                 title = "Title",
                 description = "Description"
             ),
-            showIcon = true,
-            icon = OceanIcons.PLACEHOLDER_SOLID,
+            icon = OceanIconModel(
+                icon = OceanIcons.PLACEHOLDER_SOLID,
+                tint = OceanColors.interfaceDarkDown
+            ),
             showDivider = true
         )
 

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanIconModel.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanIconModel.kt
@@ -1,0 +1,11 @@
+package br.com.useblu.oceands.model.compose
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import br.com.useblu.oceands.utils.OceanIcons
+
+data class OceanIconModel(
+    val icon: OceanIcons,
+    val tint: Color = Color.Unspecified,
+    val size: Dp? = null
+)

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanTextListReadOnlyState.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/OceanTextListReadOnlyState.kt
@@ -1,0 +1,7 @@
+package br.com.useblu.oceands.model.compose
+
+enum class OceanTextListReadOnlyState {
+    Default,
+    Disabled,
+    Loading
+}


### PR DESCRIPTION
## Objetivo
Adicionar o composto `OceanTextListReadOnly` (pré-requisito do redesenho do header do Extrato — BAN-57).

## RFs cobertos
RF-08 (pré-requisito)

## Issue
Pagnet/pagnet#16085 — PR #2 de 19 do plano de execução.

## Escopo
Novo composable em `ocean-components/src/main/java/br/com/useblu/oceands/components/compose/textlistreadonly/OceanTextListReadOnly.kt`.

API espelha o Figma Playground do componente `TextListReadOnly`:

- `contentListStyle: ContentListStyle` — reaproveita o sealed existente; passa `title`, `description`, `caption`, variante (`Default`/`Inverted`/`Strikethrough`/`Transaction`), estilos de texto, etc.
- `state: OceanTextListReadOnlyState` — `Default` / `Disabled` / `Loading` (mapeia para `enabled`/`isLoading` do `OceanContentList`).
- `showIcon` + `icon` (+ `iconTint`, `iconSize` opcionais) — ícone leading.
- `showIndicator` + `indicator: OceanTagStyle` (+ `indicatorLayout`) — tag trailing.
- `showDivider` — divider inferior (`OceanDivider`).

Composto internamente com:
- `OceanContentList` (texto)
- `OceanIcon` opcional
- `OceanTag` opcional
- `OceanDivider` opcional

Todos os valores visuais vêm de tokens (`OceanSpacing`, `OceanColors`). Sem hardcode.

## Desvios da spec
A spec original listava as props como `inverted`/`type`/`title`/`showDescription`/`description`/`showCaption`/`caption` passadas individualmente. Optei por reusar o sealed `ContentListStyle` já existente (mesma abordagem do `OceanCardReadOnly`), o que:

- Evita duplicar a enumeração de variantes.
- Permite as 4 variantes do `ContentList` no mesmo composto (`Default`, `Inverted`, `Strikethrough`, `Transaction`) sem ampliar a API.
- Mantém consistência com outros composites existentes em `ocean-android`.

O comportamento de `showDescription`/`showCaption` é coberto naturalmente pelo `ContentList`, que só renderiza esses campos se não vazios.

## Test plan
- [ ] Android Studio — abrir `OceanTextListReadOnly.kt` e rodar previews:
  - [ ] `OceanTextListReadOnlyInvertedPreview` — 5 variações (plain / divider / icon / indicator / completo)
  - [ ] `OceanTextListReadOnlyDefaultPreview` — Default / Disabled / Loading
- [ ] Verificar visualmente no preview:
  - [ ] Estado `Disabled` desbota textos (via `OceanContentList(enabled=false)`)
  - [ ] Estado `Loading` mostra shimmer no lugar do texto
  - [ ] Divider aparece só quando `showDivider=true`
  - [ ] Ícone leading e indicator trailing aparecem apenas quando as flags correspondentes estão `true`
- [ ] Grep para garantir ausência de hardcode: `grep -n "\.dp\|#" OceanTextListReadOnly.kt` — apenas referências a tokens.


<img width="389" height="785" alt="image" src="https://github.com/user-attachments/assets/35f0991f-dd7b-4cda-bf83-095525d5ac81" />

## Observações
- Lint/build via Gradle **não foi executado localmente** para evitar instalar/baixar deps automaticamente. Rodar `./gradlew :ocean-components:lint :ocean-components:assembleDebug` no CI antes do merge.
- Próxima PR dependente: #17 (blu-mobile-android) consumirá este componente após bump de versão.