### PR TITLE
fix(inline-text-list-item): align padding and title typography with Figma

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanInlineTextListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanInlineTextListItem.kt
@@ -169,7 +169,10 @@ fun OceanInlineTextListItem(
     ) {
         Row(
             modifier = Modifier
-                .padding(OceanSpacing.xs),
+                .padding(
+                    horizontal = OceanSpacing.xs,
+                    vertical = OceanSpacing.xxs
+                ),
             verticalAlignment = Alignment.CenterVertically
         ) {
             OceanInlineTextListItemTitle(

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/inlinetextlistitem/OceanInlineTextListItemSize.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/compose/inlinetextlistitem/OceanInlineTextListItemSize.kt
@@ -11,8 +11,8 @@ enum class OceanInlineTextListItemSize {
     @Composable
     fun getTitleStyle(): TextStyle {
         return when (this) {
-            DEFAULT -> OceanTextStyle.description
-            SMALL -> OceanTextStyle.captionBold
+            DEFAULT -> OceanTextStyle.paragraph
+            SMALL -> OceanTextStyle.description
         }
     }
 


### PR DESCRIPTION
## Resumo

Alinha o componente `OceanInlineTextListItem` com a spec do Figma do Ocean DS Core (variantes `Type=Default` em `Md` e `Sm`).

- Spec PRD: [pagnet#16085 — comentário com a spec completa](https://github.com/Pagnet/pagnet/issues/16085#issuecomment-4399940339)
- Figma Md: https://www.figma.com/design/PgLv9k22CHHZZ867HwN65y/Ocean-DS-Core?node-id=16358-2042
- Figma Sm: https://www.figma.com/design/PgLv9k22CHHZZ867HwN65y/Ocean-DS-Core?node-id=24157-2556

## Problema

O componente Android estava divergente da spec em dois pontos:

1. **Padding vertical** maior do que o do Figma (16dp em vez de 8dp).
2. **Tipografia do title** menor do que o value, quando a spec define que title e value usam o **mesmo estilo** dentro de cada size.

## Mudanças

### 1) `OceanInlineTextListItem.kt` — padding da Row interna

Antes:

```kotlin
Row(
    modifier = Modifier
        .padding(OceanSpacing.xs), // 16dp em todos os lados
    ...
```

Depois:

```kotlin
Row(
    modifier = Modifier
        .padding(
            horizontal = OceanSpacing.xs,  // 16dp
            vertical = OceanSpacing.xxs    // 8dp
        ),
    ...
```

### 2) `OceanInlineTextListItemSize.kt` — `getTitleStyle()`

Antes:

```kotlin
DEFAULT -> OceanTextStyle.description   // 14sp
SMALL   -> OceanTextStyle.captionBold   // 12sp
```

Depois:

```kotlin
DEFAULT -> OceanTextStyle.paragraph     // 16sp
SMALL   -> OceanTextStyle.description   // 14sp
```

`getDescriptionStyle()` (value) e o mapeamento de cores por type em `OceanInlineTextListItemDescription.kt` **não foram alterados**.

## Antes / Depois

| Propriedade               | Antes (Md)    | Depois (Md)        | Antes (Sm)    | Depois (Sm)        |
|---------------------------|---------------|--------------------|---------------|--------------------|
| Padding horizontal        | 16dp (`xs`)   | 16dp (`xs`)        | 16dp (`xs`)   | 16dp (`xs`)        |
| Padding vertical          | 16dp (`xs`)   | **8dp (`xxs`)**    | 16dp (`xs`)   | **8dp (`xxs`)**    |
| Title style               | description (14sp) | **paragraph (16sp)** | captionBold (12sp) | **description (14sp)** |
| Value style               | paragraph (16sp)   | paragraph (16sp)     | description (14sp) | description (14sp)     |
| Title color               | `interfaceDarkDown` | `interfaceDarkDown` | `interfaceDarkDown` | `interfaceDarkDown` |
| Value color (`Default`)   | `interfaceDarkDeep` | `interfaceDarkDeep` | `interfaceDarkDeep` | `interfaceDarkDeep` |

## Validação visual (precisa do autor / QA)

> Este PR foi montado sem rodar Gradle localmente (sem instalar dependências). Antes de tirar do draft, rodar a validação abaixo.

- [ ] Abrir `app` (`TextListInlineItemActivity`) em emulador/dispositivo e conferir lado a lado com os nodes do Figma:
  - Md → `16358:2042`
  - Sm → `24157:2556`
- [ ] Verificar: padding `16h × 8v`, title e value no mesmo tamanho dentro de cada size, title sempre `#67697A` (`interfaceDarkDown`), value (Default) sempre `#393B47` (`interfaceDarkDeep`).
- [ ] Gerar screenshots dos previews (`OceanInlineTextListItemPreview`) antes/depois e anexar aqui.
- [ ] Conferir consumidores in-repo abaixo.

## Consumidores in-repo / pontos de QA visual

Componentes que **renderizam `OceanInlineTextListItem`** e podem mostrar mudança visual:

- `OceanTransactionFooter` (`ocean-components/.../OceanTransactionFooter.kt`) — usado pela tela de demo `TransactionFooterViewModel` / `transactionFooterFragment`. Cada linha do footer agora tem `8dp` de padding vertical (em vez de `16dp`) e o title fica do mesmo tamanho do value. **Atenção**: footers que dependiam visualmente do title 2sp menor que o value, ou da “altura” maior por causa do padding 16v, vão encolher.

Consumidores externos (em `blu-mobile-android`) **não** foram migrados nesta PR — listar para acompanhamento de QA visual em telas que usam `OceanTransactionFooter` ou `OceanInlineTextListItem` diretamente.

## Testes

- Não há testes unitários nem screenshot baseline para `OceanInlineTextListItem` em `ocean-components/src/test`. Nada para atualizar.
- `ktlint` (pre-commit hook) rodou e passou.

## before
<img width="428" height="808" alt="image" src="https://github.com/user-attachments/assets/564dca82-dab7-4a68-a68a-2d80fad695af" />


## after
<img width="434" height="767" alt="image" src="https://github.com/user-attachments/assets/46a4f18e-ea6b-46f2-a00f-45b66892a060" />


## Notas

- Bump de versão será feito separadamente pelo time (não há commit de release nesta PR).
- Sem novo enum de size, sem parâmetro de override de style/padding, sem mudanças em outros componentes.