### PR TITLE
feat(transaction-list-expandable): expose isInverted on parent and children

### DIFF
--- a/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistexpandable/OceanTransactionListExpandableActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistexpandable/OceanTransactionListExpandableActivity.kt
@@ -181,6 +181,57 @@ private fun TransactionListExpandableSamples() {
         )
 
         OceanSpacing.StackMD()
+
+        OceanText(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = OceanSpacing.xs),
+            text = "Inverted (parent + children)",
+            style = OceanTextStyle.heading5,
+            color = OceanColors.interfaceDarkDeep
+        )
+
+        OceanSpacing.StackXXS()
+
+        OceanText(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = OceanSpacing.xs),
+            text = "primaryLabel em description + interfaceDarkDown · " +
+                "secondaryLabel em paragraph + interfaceDarkDeep",
+            style = OceanTextStyle.caption,
+            color = OceanColors.interfaceDarkDown
+        )
+
+        OceanSpacing.StackXS()
+
+        OceanTransactionListExpandable(
+            parent = OceanTransactionListExpandableItem(
+                primaryLabel = "Vendas do dia",
+                secondaryLabel = "Consolidado",
+                primaryValue = 1280.50,
+                isInverted = true
+            ),
+            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
+            items = listOf(
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito à vista",
+                    secondaryLabel = "Visa **** 1234",
+                    primaryValue = 480.00,
+                    isInverted = true
+                ),
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito parcelado",
+                    secondaryLabel = "Mastercard **** 5678",
+                    primaryValue = 800.50,
+                    isInverted = true
+                )
+            ),
+            footerText = "Fim das vendas do dia",
+            startExpanded = true
+        )
+
+        OceanSpacing.StackMD()
     }
 }
 

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
@@ -9,8 +9,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import br.com.useblu.oceands.client.R
 import br.com.useblu.oceands.client.databinding.ActivityTransactionListItemBinding
-import br.com.useblu.oceands.components.compose.list.OceanTransactionListExpandable
-import br.com.useblu.oceands.components.compose.list.OceanTransactionListExpandableItem
 import br.com.useblu.oceands.components.compose.list.OceanTransactionListItem
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.model.OceanTransactionListUIModel
@@ -127,55 +125,6 @@ private fun ExtractScreenPreview() {
             isInverted = true,
             showDivider = false,
             onClick = {}
-        )
-
-        OceanTransactionListExpandable(
-            parent = OceanTransactionListExpandableItem(
-                primaryLabel = "Vendas do dia",
-                secondaryLabel = "Consolidado",
-                primaryValue = 1280.50
-            ),
-            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
-            items = listOf(
-                OceanTransactionListExpandableItem(
-                    primaryLabel = "Crédito à vista",
-                    secondaryLabel = "Visa **** 1234",
-                    primaryValue = 480.00
-                ),
-                OceanTransactionListExpandableItem(
-                    primaryLabel = "Crédito parcelado",
-                    secondaryLabel = "Mastercard **** 5678",
-                    primaryValue = 800.50
-                )
-            ),
-            footerText = "Fim das vendas do dia",
-            startExpanded = true
-        )
-
-        OceanTransactionListExpandable(
-            parent = OceanTransactionListExpandableItem(
-                primaryLabel = "Vendas do dia",
-                secondaryLabel = "Consolidado",
-                primaryValue = 1280.50,
-                isInverted = true
-            ),
-            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
-            items = listOf(
-                OceanTransactionListExpandableItem(
-                    primaryLabel = "Crédito à vista",
-                    secondaryLabel = "Visa **** 1234",
-                    primaryValue = 480.00,
-                    isInverted = true
-                ),
-                OceanTransactionListExpandableItem(
-                    primaryLabel = "Crédito parcelado",
-                    secondaryLabel = "Mastercard **** 5678",
-                    primaryValue = 800.50,
-                    isInverted = true
-                )
-            ),
-            footerText = "Fim das vendas do dia",
-            startExpanded = true
         )
     }
 }

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/transactionlistitem/TransactionListItemActivity.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import br.com.useblu.oceands.client.R
 import br.com.useblu.oceands.client.databinding.ActivityTransactionListItemBinding
+import br.com.useblu.oceands.components.compose.list.OceanTransactionListExpandable
+import br.com.useblu.oceands.components.compose.list.OceanTransactionListExpandableItem
 import br.com.useblu.oceands.components.compose.list.OceanTransactionListItem
 import br.com.useblu.oceands.model.OceanTagType
 import br.com.useblu.oceands.model.OceanTransactionListUIModel
@@ -125,6 +127,55 @@ private fun ExtractScreenPreview() {
             isInverted = true,
             showDivider = false,
             onClick = {}
+        )
+
+        OceanTransactionListExpandable(
+            parent = OceanTransactionListExpandableItem(
+                primaryLabel = "Vendas do dia",
+                secondaryLabel = "Consolidado",
+                primaryValue = 1280.50
+            ),
+            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
+            items = listOf(
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito à vista",
+                    secondaryLabel = "Visa **** 1234",
+                    primaryValue = 480.00
+                ),
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito parcelado",
+                    secondaryLabel = "Mastercard **** 5678",
+                    primaryValue = 800.50
+                )
+            ),
+            footerText = "Fim das vendas do dia",
+            startExpanded = true
+        )
+
+        OceanTransactionListExpandable(
+            parent = OceanTransactionListExpandableItem(
+                primaryLabel = "Vendas do dia",
+                secondaryLabel = "Consolidado",
+                primaryValue = 1280.50,
+                isInverted = true
+            ),
+            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
+            items = listOf(
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito à vista",
+                    secondaryLabel = "Visa **** 1234",
+                    primaryValue = 480.00,
+                    isInverted = true
+                ),
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito parcelado",
+                    secondaryLabel = "Mastercard **** 5678",
+                    primaryValue = 800.50,
+                    isInverted = true
+                )
+            ),
+            footerText = "Fim das vendas do dia",
+            startExpanded = true
         )
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/list/OceanTransactionListExpandable.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/list/OceanTransactionListExpandable.kt
@@ -45,6 +45,7 @@ data class OceanTransactionListExpandableItem(
     val tagTitle: String = "",
     val tagType: OceanTagType = OceanTagType.Warning,
     val time: String = "",
+    val isInverted: Boolean = false,
     val onClick: () -> Unit = { }
 )
 
@@ -69,6 +70,7 @@ fun OceanParentTransactionListExpandable(
         time = item.time,
         showDivider = false,
         trailingIcon = if (isExpanded) OceanIcons.CHEVRON_UP_SOLID else OceanIcons.CHEVRON_DOWN_SOLID,
+        isInverted = item.isInverted,
         onClick = onClick
     )
 }
@@ -97,6 +99,7 @@ fun OceanChildTransactionListExpandable(
         secondaryLabelStyle = OceanTextStyle.description,
         primaryValueStyle = OceanTextStyle.heading5,
         primaryValueFormattedColor = if ((item.primaryValue ?: 0.0) <= 0.0) OceanColors.interfaceDarkDown else null,
+        isInverted = item.isInverted,
         onClick = item.onClick
     )
 }
@@ -316,6 +319,32 @@ fun OceanTransactionListExpandablePreview() {
                 )
             ),
             footerText = "Fim dos cancelamentos das retenções",
+            startExpanded = true
+        )
+
+        OceanTransactionListExpandable(
+            parent = OceanTransactionListExpandableItem(
+                primaryLabel = "Vendas do dia",
+                secondaryLabel = "Consolidado",
+                primaryValue = 1280.50,
+                isInverted = true
+            ),
+            itemsIcon = OceanIcons.LOCK_OPEN_SOLID,
+            items = listOf(
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito à vista",
+                    secondaryLabel = "Visa **** 1234",
+                    primaryValue = 480.00,
+                    isInverted = true
+                ),
+                OceanTransactionListExpandableItem(
+                    primaryLabel = "Crédito parcelado",
+                    secondaryLabel = "Mastercard **** 5678",
+                    primaryValue = 800.50,
+                    isInverted = true
+                )
+            ),
+            footerText = "Fim das vendas do dia",
             startExpanded = true
         )
     }


### PR DESCRIPTION
## Resumo

Estende o flag `isInverted` (introduzido em `OceanTransactionListItem`) ao componente expandable, cobrindo tanto o **parent** (`OceanParentTransactionListExpandable`) quanto os **children** (`OceanChildTransactionListExpandable`).

- Adiciona `isInverted: Boolean = false` em `OceanTransactionListExpandableItem`.
- Propaga `item.isInverted` para o `OceanTransactionListItem` interno em ambos os wrappers.
- **Sem regra acoplada pai → filho**: cada item carrega seu próprio flag e é honrado individualmente. Quem precisar pode inverter só o parent, só os children, ou os dois.
- Atualiza o `OceanTransactionListExpandablePreview` e o `TransactionListItemActivity` com um cenário default e um invertido lado a lado para validação visual.

## Contexto

Origem: PR Pagnet/blu-mobile-android#3632 (extrato com `isInverted` no `OceanTransactionListItem` direto). Os agrupamentos `COLLAPSE_GROUP` ficaram fora do escopo porque o expandable ainda não expunha o parâmetro. Esta PR fecha esse gap. Próxima PR no consumer (`Pagnet/blu-mobile-android`) bumpa a versão e passa `isInverted = true` no helper do `ExtractFragment`.

## Notas de implementação

- Precedência `isInverted` vs. `primaryLabelStyle/secondaryLabelStyle` explícitos já está correta no `OceanTransactionListItem` (ver linhas 188–208) — `isInverted` vence sobre os styles passados explicitamente. Sem ajuste extra necessário no item base.
- Default `false` em todas as superfícies novas → retrocompat total. Nenhum consumer existente do `OceanTransactionListExpandable` muda comportamento.

## Test plan

- [ ] Preview Compose `OceanTransactionListExpandablePreview` renderiza o novo bloco com:
  - Parent invertido: `primaryLabel` em `OceanTextStyle.description` + `OceanColors.interfaceDarkDown`; `secondaryLabel` em `OceanTextStyle.paragraph` + `OceanColors.interfaceDarkDeep`. Mantém o chevron up/down.
  - Children invertidos: idem para `primaryLabel`/`secondaryLabel`, com o leading icon do grupo, valor em `heading5` e divider interno entre filhos preservados.
- [ ] Os blocos default (`isInverted = false`) acima permanecem visualmente idênticos ao comportamento atual.
- [ ] Sample `TransactionListItemActivity` exibe o novo expandable invertido após o bloco existente, sem regressão nos itens de cima.

## Before
<img width="428" height="899" alt="image" src="https://github.com/user-attachments/assets/4211adc2-1e2c-4717-a347-53979552b6c2" />


## After
<img width="462" height="921" alt="image" src="https://github.com/user-attachments/assets/74abceaf-a09e-4463-af2c-f60c9eeefb96" />

## Refs

- Jira: [BAN-57](https://useblu.atlassian.net/browse/BAN-57)
- Spec: Pagnet/pagnet#16085 (comentário de 2026-05-07)
- Pré-req: PR ocean-ds/ocean-android#1079 (merged) — `isInverted` no `OceanTransactionListItem`
- Próximo: PR no consumer `Pagnet/blu-mobile-android` (após release com este merge)