### PR TITLE
feat(card-group): hide header when title is blank

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
@@ -78,17 +78,18 @@ fun OceanCardGroup(
         border = BorderStroke(1.dp, OceanColors.interfaceLightDown),
         onClick = { /* No-op */ }
     ) {
-        if (title.isNotBlank()) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = OceanSpacing.xs)
-                    .padding(horizontal = OceanSpacing.xs)
-                    .padding(bottom = OceanSpacing.xxxs)
-            ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = OceanSpacing.xs)
+        ) {
+            if (title.isNotBlank() || description.isNotBlank() || tag != null) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = OceanSpacing.xs)
+                        .padding(bottom = OceanSpacing.xxxs)
                 ) {
                     ContentDefault(
                         title = title,

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
@@ -78,40 +78,13 @@ fun OceanCardGroup(
         border = BorderStroke(1.dp, OceanColors.interfaceLightDown),
         onClick = { /* No-op */ }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = OceanSpacing.xs)
-        ) {
-            if (title.isNotBlank() || description.isNotBlank() || tag != null) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = OceanSpacing.xs)
-                        .padding(bottom = OceanSpacing.xxxs)
-                ) {
-                    ContentDefault(
-                        title = title,
-                        subtitle = description
-                    )
+        OceanSpacing.StackXS()
 
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    if (tag != null && tag.text.isNotEmpty()) {
-                        OceanTag(
-                            modifier = Modifier
-                                .padding(top = OceanSpacing.xxs),
-                            style = OceanTagStyle.Default(
-                                label = tag.text,
-                                layout = OceanTagLayout.Medium(),
-                                type = tag.type
-                            )
-                        )
-                    }
-                }
-            }
-        }
+        Header(
+            title = title,
+            description = description,
+            tag = tag
+        )
 
         content()
 
@@ -283,6 +256,45 @@ fun OceanCardGroup(
                     fontFamily = OceanFontFamily.BaseBold,
                     modifier = Modifier
                         .align(Alignment.Center)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Header(
+    title: String,
+    description: String,
+    tag: OceanTagModel?
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+    ) {
+        if (title.isNotBlank() || description.isNotBlank() || tag != null) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = OceanSpacing.xs)
+                    .padding(bottom = OceanSpacing.xxxs)
+            ) {
+                ContentDefault(
+                    title = title,
+                    subtitle = description
+                )
+
+                if (tag == null || tag.text.isEmpty()) return
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                OceanTag(
+                    style = OceanTagStyle.Default(
+                        label = tag.text,
+                        layout = OceanTagLayout.Medium(),
+                        type = tag.type
+                    )
                 )
             }
         }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
@@ -78,8 +78,6 @@ fun OceanCardGroup(
         border = BorderStroke(1.dp, OceanColors.interfaceLightDown),
         onClick = { /* No-op */ }
     ) {
-        OceanSpacing.StackXS()
-
         Header(
             title = title,
             description = description,
@@ -268,35 +266,35 @@ private fun Header(
     description: String,
     tag: OceanTagModel?
 ) {
+    if (title.isBlank() && description.isBlank() && tag == null) return
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .padding(top = OceanSpacing.xs)
     ) {
-        if (title.isNotBlank() || description.isNotBlank() || tag != null) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = OceanSpacing.xs)
-                    .padding(bottom = OceanSpacing.xxxs)
-            ) {
-                ContentDefault(
-                    title = title,
-                    subtitle = description
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = OceanSpacing.xs)
+                .padding(bottom = OceanSpacing.xxxs)
+        ) {
+            ContentDefault(
+                title = title,
+                subtitle = description
+            )
+
+            if (tag == null || tag.text.isEmpty()) return
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            OceanTag(
+                style = OceanTagStyle.Default(
+                    label = tag.text,
+                    layout = OceanTagLayout.Medium(),
+                    type = tag.type
                 )
-
-                if (tag == null || tag.text.isEmpty()) return
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                OceanTag(
-                    style = OceanTagStyle.Default(
-                        label = tag.text,
-                        layout = OceanTagLayout.Medium(),
-                        type = tag.type
-                    )
-                )
-            }
+            )
         }
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/content/OceanCardGroup.kt
@@ -53,7 +53,7 @@ import br.com.useblu.oceands.utils.OceanIcons
 @Composable
 fun OceanCardGroup(
     modifier: Modifier = Modifier,
-    title: String,
+    title: String = "",
     description: String = "",
     tag: OceanTagModel? = null,
     backgroundColor: Color = OceanColors.interfaceLightPure,
@@ -78,34 +78,36 @@ fun OceanCardGroup(
         border = BorderStroke(1.dp, OceanColors.interfaceLightDown),
         onClick = { /* No-op */ }
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = OceanSpacing.xs)
-                .padding(horizontal = OceanSpacing.xs)
-                .padding(bottom = OceanSpacing.xxxs)
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
+        if (title.isNotBlank()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = OceanSpacing.xs)
+                    .padding(horizontal = OceanSpacing.xs)
+                    .padding(bottom = OceanSpacing.xxxs)
             ) {
-                ContentDefault(
-                    title = title,
-                    subtitle = description
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                if (tag != null && tag.text.isNotEmpty()) {
-                    OceanTag(
-                        modifier = Modifier
-                            .padding(top = OceanSpacing.xxs),
-                        style = OceanTagStyle.Default(
-                            label = tag.text,
-                            layout = OceanTagLayout.Medium(),
-                            type = tag.type
-                        )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    ContentDefault(
+                        title = title,
+                        subtitle = description
                     )
+
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    if (tag != null && tag.text.isNotEmpty()) {
+                        OceanTag(
+                            modifier = Modifier
+                                .padding(top = OceanSpacing.xxs),
+                            style = OceanTagStyle.Default(
+                                label = tag.text,
+                                layout = OceanTagLayout.Medium(),
+                                type = tag.type
+                            )
+                        )
+                    }
                 }
             }
         }
@@ -556,6 +558,16 @@ fun OceanCardGroupPreview() {
                 showProgress = false,
                 modifier = Modifier.padding(16.dp)
             )
+
+            OceanCardGroup(
+                modifier = Modifier.padding(OceanSpacing.xs)
+            ) {
+                OceanTextListItem(
+                    title = "Sem título — conteúdo vai ao topo",
+                    description = "R$ 1.234,56",
+                    showDivider = false
+                )
+            }
         }
     }
 }

--- a/ocean-components/src/main/res/layout/ocean_card_group.xml
+++ b/ocean-components/src/main/res/layout/ocean_card_group.xml
@@ -86,7 +86,6 @@
                     app:layout_constraintEnd_toStartOf="@id/layout_action_header"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    app:ocean_visible_or_gone="@{headerTitle != null &amp;&amp; !headerTitle.isEmpty()}"
                     tools:text="Header" />
 
                 <TextView
@@ -102,7 +101,6 @@
                     app:layout_constraintEnd_toStartOf="@id/layout_action_header"
                     app:layout_constraintStart_toStartOf="@id/text_header"
                     app:layout_constraintTop_toBottomOf="@id/text_header"
-                    app:layout_goneMarginTop="0dp"
                     tools:text="Subtitle"
                     app:ocean_visible_or_gone="@{headerSubtitle != null}"/>
 
@@ -130,8 +128,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/text_view_subtitle"
-                    android:layout_marginTop="16dp"
-                    app:layout_goneMarginTop="0dp"/>
+                    android:layout_marginTop="16dp"/>
 
                 <include
                     android:id="@+id/group_cta"

--- a/ocean-components/src/main/res/layout/ocean_card_group.xml
+++ b/ocean-components/src/main/res/layout/ocean_card_group.xml
@@ -86,6 +86,7 @@
                     app:layout_constraintEnd_toStartOf="@id/layout_action_header"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
+                    app:ocean_visible_or_gone="@{headerTitle != null &amp;&amp; !headerTitle.isEmpty()}"
                     tools:text="Header" />
 
                 <TextView
@@ -101,6 +102,7 @@
                     app:layout_constraintEnd_toStartOf="@id/layout_action_header"
                     app:layout_constraintStart_toStartOf="@id/text_header"
                     app:layout_constraintTop_toBottomOf="@id/text_header"
+                    app:layout_goneMarginTop="0dp"
                     tools:text="Subtitle"
                     app:ocean_visible_or_gone="@{headerSubtitle != null}"/>
 
@@ -128,7 +130,8 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     app:layout_constraintTop_toBottomOf="@id/text_view_subtitle"
-                    android:layout_marginTop="16dp"/>
+                    android:layout_marginTop="16dp"
+                    app:layout_goneMarginTop="0dp"/>
 
                 <include
                     android:id="@+id/group_cta"


### PR DESCRIPTION
## Summary

- `OceanCardGroup` now accepts `title: String = ""` (optional)
- When `title` is blank the header `Column` (with its `OceanSpacing.xs` top + horizontal padding) is not composed at all — `content()` fills directly to the top of the card
- XML layout (`ocean_card_group.xml`): `text_header` gains `ocean_visible_or_gone` guard; subtitle and divider gain `layout_goneMarginTop="0dp"` so they don't float when the title is GONE

## Screenshot

#### Possibilita não ter header no card
<img width="390" height="107" alt="image" src="https://github.com/user-attachments/assets/9ebbb800-e48c-4d15-a01d-d16a806fb65f" />

#### Alinhamento da tag ajustado
<img width="313" height="643" alt="Screenshot 2026-05-22 at 16 08 54" src="https://github.com/user-attachments/assets/8eaf5911-95c6-4dc1-a022-bf612ac3158c" />



## Test plan

- [x] Preview `OceanCardGroupPreview` shows the new "Sem título" case with content at the top
- [x] Existing preview cases (with title) are unchanged