### PR TITLE
feat(button): add hasHorizontalPadding to OceanButton

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
@@ -243,6 +243,50 @@ fun PreviewButtonInteractive() {
         }
     }
 }
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewButtonRemoveHorizontalPadding() {
+    OceanTheme {
+        Column(
+            modifier = Modifier
+                .background(color = OceanColors.interfaceLightPure)
+                .padding(OceanSpacing.md)
+        ) {
+            OceanText(
+                text = "Conteúdo de referência",
+                fontSize = OceanFontSize.xs,
+                fontFamily = OceanFontFamily.BaseBold
+            )
+
+            OceanSpacing.StackXS()
+
+            OceanText(
+                text = "removeHorizontalPadding = false (padrão)",
+                fontSize = OceanFontSize.xxxs
+            )
+            OceanButton(
+                text = "Ver detalhes",
+                buttonStyle = OceanButtonStyle.TertiarySmall,
+                onClick = { }
+            )
+
+            OceanSpacing.StackSM()
+
+            OceanText(
+                text = "removeHorizontalPadding = true",
+                fontSize = OceanFontSize.xxxs
+            )
+            OceanButton(
+                text = "Ver detalhes",
+                buttonStyle = OceanButtonStyle.TertiarySmall,
+                removeHorizontalPadding = true,
+                onClick = { }
+            )
+        }
+    }
+}
+
 enum class Orientation {
     Horizontal,
     Vertical

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
@@ -39,6 +39,7 @@ fun PreviewButtonInteractive() {
     var showIcon by remember { mutableStateOf(true) }
     var isDisabled by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
+    var removeHorizontalPadding by remember { mutableStateOf(false) }
     var selectedSize by remember { mutableStateOf("Medium") }
     var selectedVariant by remember { mutableStateOf("Primary") }
 
@@ -132,6 +133,7 @@ fun PreviewButtonInteractive() {
                 disabled = isDisabled,
                 modifier = Modifier,
                 buttonStyle = selectedStyle,
+                removeHorizontalPadding = removeHorizontalPadding,
                 onClick = { }
             )
 
@@ -224,6 +226,20 @@ fun PreviewButtonInteractive() {
                     onClick = { isLoading = !isLoading }
                 )
             }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                OceanButton(
+                    text = if (removeHorizontalPadding) {
+                        "Restaurar Padding Horizontal"
+                    } else {
+                        "Remover Padding Horizontal"
+                    },
+                    buttonStyle = OceanButtonStyle.TertiarySmall,
+                    onClick = { removeHorizontalPadding = !removeHorizontalPadding }
+                )
+            }
         }
     }
 }
@@ -238,7 +254,8 @@ data class OceanButtonModel(
     val buttonStyle: OceanButtonStyle,
     val showProgress: Boolean = false,
     val icon: OceanIcons? = null,
-    val disabled: Boolean = false
+    val disabled: Boolean = false,
+    val removeHorizontalPadding: Boolean = false
 )
 
 @Composable
@@ -253,7 +270,8 @@ fun OceanButton(
         modifier = modifier,
         showProgress = button.showProgress,
         icon = button.icon,
-        disabled = button.disabled
+        disabled = button.disabled,
+        removeHorizontalPadding = button.removeHorizontalPadding
     )
 }
 
@@ -265,7 +283,8 @@ fun OceanButton(
     modifier: Modifier = Modifier,
     showProgress: Boolean = false,
     icon: OceanIcons? = null,
-    disabled: Boolean = false
+    disabled: Boolean = false,
+    removeHorizontalPadding: Boolean = false
 ) {
     Button(
         onClick = { if (!showProgress) onClick.invoke() },
@@ -275,7 +294,7 @@ fun OceanButton(
         shape = OceanBorderRadius.Circle.allCorners.shape(),
         enabled = !disabled,
         contentPadding = PaddingValues(
-            horizontal = buttonStyle.getHorizontalPadding()
+            horizontal = if (removeHorizontalPadding) 0.dp else buttonStyle.getHorizontalPadding()
         )
     ) {
         if (!showProgress) {

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanButton.kt
@@ -39,7 +39,7 @@ fun PreviewButtonInteractive() {
     var showIcon by remember { mutableStateOf(true) }
     var isDisabled by remember { mutableStateOf(false) }
     var isLoading by remember { mutableStateOf(false) }
-    var removeHorizontalPadding by remember { mutableStateOf(false) }
+    var hasHorizontalPadding by remember { mutableStateOf(true) }
     var selectedSize by remember { mutableStateOf("Medium") }
     var selectedVariant by remember { mutableStateOf("Primary") }
 
@@ -133,7 +133,7 @@ fun PreviewButtonInteractive() {
                 disabled = isDisabled,
                 modifier = Modifier,
                 buttonStyle = selectedStyle,
-                removeHorizontalPadding = removeHorizontalPadding,
+                hasHorizontalPadding = hasHorizontalPadding,
                 onClick = { }
             )
 
@@ -231,13 +231,13 @@ fun PreviewButtonInteractive() {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 OceanButton(
-                    text = if (removeHorizontalPadding) {
-                        "Restaurar Padding Horizontal"
-                    } else {
+                    text = if (hasHorizontalPadding) {
                         "Remover Padding Horizontal"
+                    } else {
+                        "Restaurar Padding Horizontal"
                     },
                     buttonStyle = OceanButtonStyle.TertiarySmall,
-                    onClick = { removeHorizontalPadding = !removeHorizontalPadding }
+                    onClick = { hasHorizontalPadding = !hasHorizontalPadding }
                 )
             }
         }
@@ -246,7 +246,7 @@ fun PreviewButtonInteractive() {
 
 @Preview(showBackground = true)
 @Composable
-private fun PreviewButtonRemoveHorizontalPadding() {
+private fun PreviewButtonHasHorizontalPadding() {
     OceanTheme {
         Column(
             modifier = Modifier
@@ -262,7 +262,7 @@ private fun PreviewButtonRemoveHorizontalPadding() {
             OceanSpacing.StackXS()
 
             OceanText(
-                text = "removeHorizontalPadding = false (padrão)",
+                text = "hasHorizontalPadding = true (padrão)",
                 fontSize = OceanFontSize.xxxs
             )
             OceanButton(
@@ -274,13 +274,13 @@ private fun PreviewButtonRemoveHorizontalPadding() {
             OceanSpacing.StackSM()
 
             OceanText(
-                text = "removeHorizontalPadding = true",
+                text = "hasHorizontalPadding = false",
                 fontSize = OceanFontSize.xxxs
             )
             OceanButton(
                 text = "Ver detalhes",
                 buttonStyle = OceanButtonStyle.TertiarySmall,
-                removeHorizontalPadding = true,
+                hasHorizontalPadding = false,
                 onClick = { }
             )
         }
@@ -299,7 +299,7 @@ data class OceanButtonModel(
     val showProgress: Boolean = false,
     val icon: OceanIcons? = null,
     val disabled: Boolean = false,
-    val removeHorizontalPadding: Boolean = false
+    val hasHorizontalPadding: Boolean = true
 )
 
 @Composable
@@ -315,7 +315,7 @@ fun OceanButton(
         showProgress = button.showProgress,
         icon = button.icon,
         disabled = button.disabled,
-        removeHorizontalPadding = button.removeHorizontalPadding
+        hasHorizontalPadding = button.hasHorizontalPadding
     )
 }
 
@@ -328,7 +328,7 @@ fun OceanButton(
     showProgress: Boolean = false,
     icon: OceanIcons? = null,
     disabled: Boolean = false,
-    removeHorizontalPadding: Boolean = false
+    hasHorizontalPadding: Boolean = true
 ) {
     Button(
         onClick = { if (!showProgress) onClick.invoke() },
@@ -338,7 +338,7 @@ fun OceanButton(
         shape = OceanBorderRadius.Circle.allCorners.shape(),
         enabled = !disabled,
         contentPadding = PaddingValues(
-            horizontal = if (removeHorizontalPadding) 0.dp else buttonStyle.getHorizontalPadding()
+            horizontal = if (hasHorizontalPadding) buttonStyle.getHorizontalPadding() else 0.dp
         )
     ) {
         if (!showProgress) {


### PR DESCRIPTION
## Summary
Adds an opt-in `hasHorizontalPadding` flag (default `true`) to `OceanButton` / `OceanButtonModel`. When `false`, the button renders **without** the size-based horizontal content padding, so a tertiary button can be aligned to the surrounding content — matching web's `textTertiary` and iOS (where tertiary styles already use zero horizontal padding via `getPadding() == .zero`).

## What changed
- `OceanButtonModel`: new `hasHorizontalPadding: Boolean = true`
- `OceanButton(...)`: new `hasHorizontalPadding` param; `contentPadding` uses the style's size-based padding when `true`, otherwise `0.dp`
- Interactive preview (`PreviewButtonInteractive`): toggle to demonstrate the behavior
- Dedicated static preview (`PreviewButtonHasHorizontalPadding`): compares `true` vs `false` side by side

## Backward compatibility
Defaults to `true` → existing buttons are unaffected.

## Motivation
Consumers (e.g. blu-mobile-android's contextual hero) currently apply a negative `Modifier.offset` workaround to align tertiary buttons to the content. This moves that responsibility into the design system, in parity with iOS/web.

##Evidences
<img width="632" height="808" alt="image" src="https://github.com/user-attachments/assets/697ece26-d23c-4782-a998-d3352caa7df5" />
