### PR TITLE
chore: alinha AGP para 9.1.0 (Gradle 9.4.1)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-gradle = "9.0.1"
+gradle = "9.1.0"
 junitVersion = "4.13.2"
 kotlinGradlePlugin = "2.3.0"
 benchmarkBaselineProfileGradlePlugin = "1.5.0-alpha03"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## O que está sendo implementado

Alinha o AGP do `ocean-android` para resolver o conflito de versão no build composto do app Blu:

```
Using multiple versions of the Android Gradle Plugin [9.0.1, 9.1.0] across Gradle builds is not allowed.
Affected builds: [:, :mobile-android-architecture, :ocean-android].
```

O `blu-mobile-android` inclui `ocean-android` e `mobile-android-architecture` via `includeBuild` (composite build local). Como o `mobile-android-architecture` e o app já estão em **AGP 9.1.0**, o `ocean-android` (em 9.0.1) ficava como a versão divergente.

### Mudança
- `gradle/libs.versions.toml`: `gradle` (AGP) `9.0.1 → 9.1.0`.
- `gradle/wrapper/gradle-wrapper.properties`: Gradle `9.3.1 → 9.4.1` (mesmo pareamento AGP↔Gradle dos demais repos).

## Comentários e instruções

- PR companheiro no app: `Pagnet/blu-mobile-android#3674` (sobe o app para 9.1.0). Os dois juntos eliminam o conflito no build composto.
- `kotlin` mantido inalterado — o erro é só de AGP.
- Build não executado neste ambiente — **validar na CI**.

## Alteração testada em

- **OS:** Android (validação na CI)
