### PR TITLE
feat(storybook): Storybook interativo + galeria de snapshots (Banner)

### DIFF
--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -105,6 +105,9 @@ jobs:
           name: ios-snapshots
           path: gallery/images/ios
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        with:
+          # habilita o GitHub Pages (Source = Actions) automaticamente, sem passo manual em Settings
+          enablement: true
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: gallery

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -1,0 +1,95 @@
+name: Banner Storybook Gallery
+
+# Gera os snapshots do componente REAL (iOS + Android) e publica a galeria web no
+# GitHub Pages. Ninguém precisa rodar Xcode/Android Studio para visualizar — basta abrir o link.
+#
+# Pré-requisitos no repositório:
+#   - Settings > Pages > Source = "GitHub Actions"
+#   - (ocean-ios é público; se virar privado, configurar token de checkout cross-repo)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [feat/ocean-banner-component]
+    paths:
+      - 'ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/**'
+      - 'ocean-components/src/test/java/br/com/useblu/oceands/snapshot/**'
+      - 'gallery/**'
+      - '.github/workflows/banner-gallery.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: banner-gallery
+  cancel-in-progress: true
+
+jobs:
+  android-snapshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: android-actions/setup-android@v3
+      - name: Render Banner snapshots (Robolectric)
+        run: ./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-snapshots
+          path: ocean-components/build/outputs/banner-snapshots/*.png
+          if-no-files-found: error
+
+  ios-snapshots:
+    runs-on: macos-14
+    steps:
+      - name: Checkout ocean-ios
+        uses: actions/checkout@v4
+        with:
+          repository: ocean-ds/ocean-ios
+          ref: feat/ocean-banner-component
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode.app
+      - name: Render Banner snapshots (XCTest)
+        run: |
+          xcodebuild test \
+            -project OceanDesignSystem.xcodeproj \
+            -scheme OceanDesignSystem \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -only-testing:OceanDesignSystemTests/BannerSnapshotTests \
+            CODE_SIGNING_ALLOWED=NO | xcpretty || true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ios-snapshots
+          path: OceanDesignSystemTests/__BannerSnapshots__/*.png
+          if-no-files-found: error
+
+  publish:
+    needs: [android-snapshots, ios-snapshots]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Android snapshots
+        uses: actions/download-artifact@v4
+        with:
+          name: android-snapshots
+          path: gallery/images/android
+      - name: Download iOS snapshots
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-snapshots
+          path: gallery/images/ios
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: gallery
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -70,9 +70,9 @@ jobs:
           echo "Schemes do package:"; xcodebuild -list || true
           DEST_ID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE "[0-9A-Fa-f-]{36}")
           echo "Simulador: $DEST_ID"
-          # OceanComponents é o scheme do produto do package; o test action inclui OceanBannerSnapshotTests
+          # Ocean-Package é o scheme agregado do package (tem test action com OceanBannerSnapshotTests)
           xcodebuild test \
-            -scheme OceanComponents \
+            -scheme Ocean-Package \
             -destination "id=$DEST_ID" \
             CODE_SIGNING_ALLOWED=NO
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           repository: ocean-ds/ocean-ios
           ref: feat/ocean-banner-storybook
+          # pasta "ocean-ios" para casar com o relativePath "../ocean-ios" do pacote local no .xcodeproj
+          path: ocean-ios
       - name: Select Xcode 16+
         run: |
           XC=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
@@ -65,7 +67,7 @@ jobs:
           DEST_ID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE "[0-9A-Fa-f-]{36}")
           echo "Simulador: $DEST_ID"
           xcodebuild test \
-            -project OceanDesignSystem.xcodeproj \
+            -project ocean-ios/OceanDesignSystem.xcodeproj \
             -scheme OceanDesignSystem \
             -destination "id=$DEST_ID" \
             -only-testing:OceanDesignSystemTests/BannerSnapshotTests \
@@ -73,7 +75,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-snapshots
-          path: OceanDesignSystemTests/__BannerSnapshots__/*.png
+          path: ocean-ios/OceanDesignSystemTests/__BannerSnapshots__/*.png
           if-no-files-found: error
 
   publish:

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -10,17 +10,16 @@ name: Banner Storybook Gallery
 on:
   workflow_dispatch:
   push:
-    branches: [feat/ocean-banner-component]
+    branches: [feat/ocean-banner-storybook]
     paths:
       - 'ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/**'
       - 'ocean-components/src/test/java/br/com/useblu/oceands/snapshot/**'
       - 'gallery/**'
       - '.github/workflows/banner-gallery.yml'
 
+# Permissão padrão mínima (somente leitura); as permissões de escrita ficam no job que precisa.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: banner-gallery
@@ -30,15 +29,15 @@ jobs:
   android-snapshots:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '21'
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
       - name: Render Banner snapshots (Robolectric)
         run: ./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: android-snapshots
           path: ocean-components/build/outputs/banner-snapshots/*.png
@@ -48,7 +47,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout ocean-ios
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ocean-ds/ocean-ios
           ref: feat/ocean-banner-component
@@ -61,8 +60,8 @@ jobs:
             -scheme OceanDesignSystem \
             -destination 'platform=iOS Simulator,name=iPhone 15' \
             -only-testing:OceanDesignSystemTests/BannerSnapshotTests \
-            CODE_SIGNING_ALLOWED=NO | xcpretty || true
-      - uses: actions/upload-artifact@v4
+            CODE_SIGNING_ALLOWED=NO
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-snapshots
           path: OceanDesignSystemTests/__BannerSnapshots__/*.png
@@ -71,25 +70,29 @@ jobs:
   publish:
     needs: [android-snapshots, ios-snapshots]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download Android snapshots
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: android-snapshots
           path: gallery/images/android
       - name: Download iOS snapshots
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ios-snapshots
           path: gallery/images/ios
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: gallery
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -104,10 +104,9 @@ jobs:
         with:
           name: ios-snapshots
           path: gallery/images/ios
+      # Pages precisa estar habilitado em Settings > Pages > Source: GitHub Actions
+      # (o token do CI não tem permissão para habilitar nesta org).
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-        with:
-          # habilita o GitHub Pages (Source = Actions) automaticamente, sem passo manual em Settings
-          enablement: true
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: gallery

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -31,6 +31,8 @@ jobs:
           java-version: '21'
       - uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
       - name: Render Banner snapshots (Robolectric)
+        env:
+          BANNER_SNAPSHOT_GENERATE: "true"
         run: ./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -7,15 +7,10 @@ name: Banner Storybook Gallery
 #   - Settings > Pages > Source = "GitHub Actions"
 #   - (ocean-ios é público; se virar privado, configurar token de checkout cross-repo)
 
+# Pipeline de publicação (não é gate de PR): rode manualmente em Actions > Run workflow,
+# após habilitar Settings > Pages > Source = GitHub Actions.
 on:
   workflow_dispatch:
-  push:
-    branches: [feat/ocean-banner-storybook]
-    paths:
-      - 'ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/**'
-      - 'ocean-components/src/test/java/br/com/useblu/oceands/snapshot/**'
-      - 'gallery/**'
-      - '.github/workflows/banner-gallery.yml'
 
 # Permissão padrão mínima (somente leitura); as permissões de escrita ficam no job que precisa.
 permissions:

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -65,15 +65,15 @@ jobs:
       - name: Render Banner snapshots (Swift Package test)
         working-directory: ocean-ios
         run: |
-          echo "Schemes disponíveis:"; xcodebuild -list || true
-          SCHEME=$(xcodebuild -list -json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=(d.get('workspace') or d.get('project') or {}).get('schemes',[]); c=[n for n in s if n.endswith('-Package')] or [n for n in s if 'BannerSnapshot' in n] or [n for n in s if n=='OceanComponents'] or s; print(c[0] if c else '')")
-          echo "Scheme escolhido: $SCHEME"
+          # Esconde o .xcodeproj para o xcodebuild operar sobre o Swift Package (e não o app)
+          mv OceanDesignSystem.xcodeproj ../OceanDesignSystem.xcodeproj.hidden
+          echo "Schemes do package:"; xcodebuild -list || true
           DEST_ID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE "[0-9A-Fa-f-]{36}")
           echo "Simulador: $DEST_ID"
+          # OceanComponents é o scheme do produto do package; o test action inclui OceanBannerSnapshotTests
           xcodebuild test \
-            -scheme "$SCHEME" \
+            -scheme OceanComponents \
             -destination "id=$DEST_ID" \
-            -only-testing:OceanBannerSnapshotTests \
             CODE_SIGNING_ALLOWED=NO
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -7,10 +7,17 @@ name: Banner Storybook Gallery
 #   - Settings > Pages > Source = "GitHub Actions"
 #   - (ocean-ios é público; se virar privado, configurar token de checkout cross-repo)
 
-# Pipeline de publicação (não é gate de PR): rode manualmente em Actions > Run workflow,
-# após habilitar Settings > Pages > Source = GitHub Actions.
+# Pipeline de publicação da galeria. Requer: Settings > Pages > Source = "GitHub Actions".
+# Roda manualmente (Run workflow) ou a cada push nesta branch que toque os caminhos abaixo.
 on:
   workflow_dispatch:
+  push:
+    branches: [feat/ocean-banner-storybook]
+    paths:
+      - 'ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/**'
+      - 'ocean-components/src/test/java/br/com/useblu/oceands/snapshot/**'
+      - 'gallery/**'
+      - '.github/workflows/banner-gallery.yml'
 
 # Permissão padrão mínima (somente leitura); as permissões de escrita ficam no job que precisa.
 permissions:
@@ -66,6 +73,8 @@ jobs:
 
   publish:
     needs: [android-snapshots, ios-snapshots]
+    # Publica mesmo que um dos jobs de snapshot falhe (mostra o que conseguiu gerar).
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -77,11 +86,13 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download Android snapshots
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: android-snapshots
           path: gallery/images/android
       - name: Download iOS snapshots
+        continue-on-error: true
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ios-snapshots

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -62,34 +62,30 @@ jobs:
           XC=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
           sudo xcode-select -switch "${XC:-/Applications/Xcode.app}"
           xcodebuild -version
-      - name: Render Banner snapshots (XCTest)
+      - name: Render Banner snapshots (Swift Package test)
+        working-directory: ocean-ios
         run: |
+          echo "Schemes disponíveis:"; xcodebuild -list || true
+          SCHEME=$(xcodebuild -list -json 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); s=(d.get('workspace') or d.get('project') or {}).get('schemes',[]); c=[n for n in s if n.endswith('-Package')] or [n for n in s if 'BannerSnapshot' in n] or [n for n in s if n=='OceanComponents'] or s; print(c[0] if c else '')")
+          echo "Scheme escolhido: $SCHEME"
           DEST_ID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE "[0-9A-Fa-f-]{36}")
           echo "Simulador: $DEST_ID"
           xcodebuild test \
-            -project ocean-ios/OceanDesignSystem.xcodeproj \
-            -scheme OceanDesignSystem \
+            -scheme "$SCHEME" \
             -destination "id=$DEST_ID" \
-            -only-testing:OceanDesignSystemTests/BannerSnapshotTests \
+            -only-testing:OceanBannerSnapshotTests \
             CODE_SIGNING_ALLOWED=NO
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-snapshots
-          path: ocean-ios/OceanDesignSystemTests/__BannerSnapshots__/*.png
+          path: ocean-ios/Tests/OceanBannerSnapshotTests/__BannerSnapshots__/*.png
           if-no-files-found: error
 
-  publish:
+  gallery:
     needs: [android-snapshots, ios-snapshots]
-    # Publica mesmo que um dos jobs de snapshot falhe (mostra o que conseguiu gerar).
+    # Monta a galeria mesmo que um dos jobs de snapshot falhe (publica o que conseguiu gerar).
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Download Android snapshots
@@ -104,12 +100,11 @@ jobs:
         with:
           name: ios-snapshots
           path: gallery/images/ios
-      # Pages precisa estar habilitado em Settings > Pages > Source: GitHub Actions
-      # (o token do CI não tem permissão para habilitar nesta org).
-      - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      # Sem GitHub Pages (token do CI não habilita nesta org): a galeria sai como artifact.
+      # Baixe "banner-gallery" no run, descompacte e abra gallery/index.html no navegador.
+      - name: Upload gallery (download e abra index.html)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
+          name: banner-gallery
           path: gallery
-      - name: Deploy to GitHub Pages
-        id: deploy
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+          if-no-files-found: error

--- a/.github/workflows/banner-gallery.yml
+++ b/.github/workflows/banner-gallery.yml
@@ -48,21 +48,26 @@ jobs:
           if-no-files-found: error
 
   ios-snapshots:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout ocean-ios
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ocean-ds/ocean-ios
-          ref: feat/ocean-banner-component
-      - name: Select Xcode
-        run: sudo xcode-select -switch /Applications/Xcode.app
+          ref: feat/ocean-banner-storybook
+      - name: Select Xcode 16+
+        run: |
+          XC=$(ls -d /Applications/Xcode_16*.app 2>/dev/null | sort -V | tail -1)
+          sudo xcode-select -switch "${XC:-/Applications/Xcode.app}"
+          xcodebuild -version
       - name: Render Banner snapshots (XCTest)
         run: |
+          DEST_ID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | grep -oE "[0-9A-Fa-f-]{36}")
+          echo "Simulador: $DEST_ID"
           xcodebuild test \
             -project OceanDesignSystem.xcodeproj \
             -scheme OceanDesignSystem \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination "id=$DEST_ID" \
             -only-testing:OceanDesignSystemTests/BannerSnapshotTests \
             CODE_SIGNING_ALLOWED=NO
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,6 +86,7 @@
         <activity android:name=".ui.cardbalance.CardBalanceActivity" />
         <activity android:name=".ui.cardoption.CardOptionActivity" />
         <activity android:name=".ui.banner.BannerActivity" />
+        <activity android:name=".storybook.StorybookActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/br/com/useblu/oceands/client/storybook/BannerStory.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/storybook/BannerStory.kt
@@ -1,0 +1,103 @@
+package br.com.useblu.oceands.client.storybook
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import br.com.useblu.oceands.R as OceanR
+import br.com.useblu.oceands.components.compose.banner.OceanBanner
+import br.com.useblu.oceands.components.compose.banner.OceanBannerKind
+import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
+import br.com.useblu.oceands.utils.image.OceanImageProxy
+
+private val bannerSizes = listOf("Large", "Small")
+private val bannerStyles = listOf("Neutral", "Brand", "Warning", "Negative", "Emphasys")
+private val bannerImages = listOf("None", "Local", "URL")
+
+private const val SAMPLE_IMAGE_URL =
+    "https://portal-cob.blu.com.br/assets/credblu/" +
+        "image_hero_bill_overdue_negative-" +
+        "b5bb0660469f00e54ae453279e54f24800fb953f9d4664d704f89f3ebadd9203.webp"
+
+/**
+ * Story do componente [OceanBanner] — registrada em [StorybookCatalog].
+ */
+val bannerStory = StorybookStory(
+    name = "Banner",
+    group = "Feedback",
+    content = { BannerStoryContent() }
+)
+
+@Composable
+private fun BannerStoryContent() {
+    var sizeIndex by remember { mutableIntStateOf(0) }
+    var styleIndex by remember { mutableIntStateOf(0) }
+    var imageIndex by remember { mutableIntStateOf(1) }
+    var title by remember { mutableStateOf("Banner Title") }
+    var description by remember {
+        mutableStateOf("This is a description for the banner component.")
+    }
+    var primaryCta by remember { mutableStateOf(true) }
+    var primaryEnabled by remember { mutableStateOf(true) }
+    var secondaryCta by remember { mutableStateOf(false) }
+
+    val image: OceanImageProxy? = when (imageIndex) {
+        1 -> OceanImageProxy.Resource(resId = OceanR.drawable.image_placeholder)
+        2 -> OceanImageProxy.URL(url = SAMPLE_IMAGE_URL)
+        else -> null
+    }
+
+    val kind: OceanBannerKind = if (sizeIndex == 0) {
+        OceanBannerKind.Large(image = image)
+    } else {
+        OceanBannerKind.Small(image = image)
+    }
+
+    val style: OceanBannerStyle = when (styleIndex) {
+        1 -> OceanBannerStyle.Brand
+        2 -> OceanBannerStyle.Warning
+        3 -> OceanBannerStyle.Negative
+        4 -> OceanBannerStyle.Emphasys
+        else -> OceanBannerStyle.Neutral
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+    ) {
+        StorybookCanvas {
+            OceanBanner(
+                modifier = Modifier.fillMaxWidth(),
+                style = style,
+                kind = kind,
+                title = title,
+                description = description,
+                ctaTitle = if (primaryCta) "Ação principal" else "",
+                onCtaClick = {},
+                ctaIsEnabled = primaryEnabled,
+                secondaryCtaTitle = if (secondaryCta) "Secundária" else "",
+                onSecondaryCtaClick = {}
+            )
+        }
+
+        StorybookControlsPanel {
+            StorybookSegmented("Size", bannerSizes, sizeIndex) { sizeIndex = it }
+            StorybookSegmented("Style", bannerStyles, styleIndex) { styleIndex = it }
+            StorybookSegmented("Image", bannerImages, imageIndex) { imageIndex = it }
+            StorybookTextField("Title", title) { title = it }
+            StorybookTextField("Description", description) { description = it }
+            StorybookSwitch("Primary CTA", primaryCta) { primaryCta = it }
+            StorybookSwitch("Primary CTA enabled", primaryEnabled) { primaryEnabled = it }
+            StorybookSwitch("Secondary CTA", secondaryCta) { secondaryCta = it }
+        }
+    }
+}

--- a/app/src/main/java/br/com/useblu/oceands/client/storybook/Storybook.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/storybook/Storybook.kt
@@ -1,0 +1,142 @@
+package br.com.useblu.oceands.client.storybook
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import br.com.useblu.oceands.components.compose.OceanDivider
+import br.com.useblu.oceands.components.compose.OceanText
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanSpacing
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
+
+/**
+ * Descreve uma "story" do Storybook: um componente do Ocean DS renderizado de forma
+ * isolada com um painel de controles interativos para validar suas variantes.
+ *
+ * Para adicionar um novo componente ao Storybook, crie a story (ver [bannerStory] como
+ * referência) e registre-a em [StorybookCatalog.stories].
+ */
+data class StorybookStory(
+    val name: String,
+    val group: String,
+    val content: @Composable () -> Unit
+)
+
+/**
+ * Catálogo central de stories. Cada componente do Ocean DS que entrar no Storybook
+ * deve ser registrado aqui.
+ */
+object StorybookCatalog {
+    val stories: List<StorybookStory> = listOf(
+        bannerStory
+    )
+}
+
+/**
+ * Raiz do Storybook: alterna entre a lista de componentes e a visualização isolada
+ * de uma story.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StorybookApp() {
+    var selected by remember { mutableStateOf<StorybookStory?>(null) }
+
+    Scaffold { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            val current = selected
+            if (current == null) {
+                StorybookHeader(title = "Storybook", onBack = null)
+                StorybookList(
+                    stories = StorybookCatalog.stories,
+                    onSelect = { selected = it }
+                )
+            } else {
+                StorybookHeader(title = current.name, onBack = { selected = null })
+                current.content()
+            }
+        }
+    }
+}
+
+@Composable
+private fun StorybookHeader(
+    title: String,
+    onBack: (() -> Unit)?
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (onBack != null) {
+            TextButton(onClick = onBack) {
+                Text(text = "← Voltar")
+            }
+        }
+        OceanText(
+            text = title,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    start = OceanSpacing.xs,
+                    end = OceanSpacing.xs,
+                    bottom = OceanSpacing.xxs
+                ),
+            style = OceanTextStyle.heading3
+        )
+        OceanDivider()
+    }
+}
+
+@Composable
+private fun StorybookList(
+    stories: List<StorybookStory>,
+    onSelect: (StorybookStory) -> Unit
+) {
+    val grouped = stories.groupBy { it.group }.toSortedMap()
+
+    LazyColumn(modifier = Modifier.fillMaxSize()) {
+        grouped.forEach { (group, groupStories) ->
+            item {
+                Text(
+                    text = group.uppercase(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            start = OceanSpacing.xs,
+                            end = OceanSpacing.xs,
+                            top = OceanSpacing.xs,
+                            bottom = OceanSpacing.xxs
+                        ),
+                    style = OceanTextStyle.caption.copy(color = OceanColors.interfaceDarkUp)
+                )
+            }
+            items(groupStories.sortedBy { it.name }) { story ->
+                OceanText(
+                    text = story.name,
+                    modifier = Modifier
+                        .clickable { onSelect(story) }
+                        .fillMaxWidth()
+                        .padding(OceanSpacing.xs),
+                    style = OceanTextStyle.subtitle1,
+                    color = OceanColors.interfaceDarkDown
+                )
+                OceanDivider()
+            }
+        }
+    }
+}

--- a/app/src/main/java/br/com/useblu/oceands/client/storybook/StorybookActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/storybook/StorybookActivity.kt
@@ -1,0 +1,25 @@
+package br.com.useblu.oceands.client.storybook
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import br.com.useblu.oceands.components.compose.OceanTheme
+
+/**
+ * Ponto de entrada do Storybook do Ocean DS Android.
+ *
+ * Catálogo interativo de componentes para testar e validar visualmente cada componente
+ * em isolamento, com controles (knobs) que alteram seus parâmetros em tempo real.
+ */
+class StorybookActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            OceanTheme {
+                StorybookApp()
+            }
+        }
+    }
+}

--- a/app/src/main/java/br/com/useblu/oceands/client/storybook/StorybookControls.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/storybook/StorybookControls.kt
@@ -1,0 +1,133 @@
+package br.com.useblu.oceands.client.storybook
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import br.com.useblu.oceands.components.compose.OceanDivider
+import br.com.useblu.oceands.components.compose.OceanText
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanSpacing
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
+
+/**
+ * Área de pré-visualização ("canvas") onde o componente é renderizado isolado, sobre um
+ * fundo neutro que evidencia os limites do componente.
+ */
+@Composable
+fun StorybookCanvas(content: @Composable () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(OceanColors.interfaceLightPure)
+            .padding(OceanSpacing.xs)
+    ) {
+        content()
+    }
+}
+
+/**
+ * Painel de controles (knobs) que altera os parâmetros do componente em tempo real.
+ */
+@Composable
+fun StorybookControlsPanel(content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(OceanSpacing.xs)
+    ) {
+        OceanText(
+            text = "CONTROLS",
+            style = OceanTextStyle.caption.copy(color = OceanColors.interfaceDarkUp)
+        )
+        OceanDivider()
+        content()
+    }
+}
+
+/**
+ * Controle de seleção única entre poucas opções (ex.: size, style).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StorybookSegmented(
+    label: String,
+    options: List<String>,
+    selectedIndex: Int,
+    onSelect: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = OceanSpacing.xxs)
+    ) {
+        Text(text = label)
+        Row(
+            modifier = Modifier.horizontalScroll(rememberScrollState()),
+            horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xxs)
+        ) {
+            options.forEachIndexed { index, option ->
+                FilterChip(
+                    selected = index == selectedIndex,
+                    onClick = { onSelect(index) },
+                    label = { Text(text = option) }
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Controle booleano (ex.: exibir/ocultar CTA, habilitar/desabilitar).
+ */
+@Composable
+fun StorybookSwitch(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = OceanSpacing.xxs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = label)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+/**
+ * Controle de texto livre (ex.: title, description).
+ */
+@Composable
+fun StorybookTextField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(text = label) },
+        singleLine = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = OceanSpacing.xxs)
+    )
+}

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
@@ -37,6 +37,7 @@ import br.com.useblu.oceands.client.ui.badges.BadgesActivity
 import br.com.useblu.oceands.client.ui.balance.BalanceActivity
 import br.com.useblu.oceands.client.ui.banner.BannerActivity
 import br.com.useblu.oceands.client.ui.blubalance.BluBalanceActivity
+import br.com.useblu.oceands.client.storybook.StorybookActivity
 import br.com.useblu.oceands.client.ui.bottomnavigation.BottomNavigationActivity
 import br.com.useblu.oceands.client.ui.buttons.ButtonsActivity
 import br.com.useblu.oceands.client.ui.cardbalance.CardBalanceActivity
@@ -168,6 +169,7 @@ class HomeActivity : AppCompatActivity() {
                     LazyColumn(
                         modifier = Modifier.padding(it)
                     ) {
+                        textAction(text = "🎨 Storybook", onClick = { onClickStorybook() })
                         textAction(text = "Accordion", onClick = { onClickAccordion() })
                         textAction(text = "Alerts", onClick = { onClickAlert() })
                         textAction(text = "Badges", onClick = { onClickBadges() })
@@ -328,6 +330,11 @@ class HomeActivity : AppCompatActivity() {
 
     private fun onClickBanner() {
         val intent = Intent(this, BannerActivity::class.java)
+        startActivity(intent)
+    }
+
+    private fun onClickStorybook() {
+        val intent = Intent(this, StorybookActivity::class.java)
         startActivity(intent)
     }
 

--- a/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/home/HomeActivity.kt
@@ -31,13 +31,13 @@ import androidx.lifecycle.lifecycleScope
 import br.com.useblu.oceands.adapter.OceanBottomListSheetAdapter
 import br.com.useblu.oceands.adapter.OceanUnorderedListAdapter
 import br.com.useblu.oceands.client.R
+import br.com.useblu.oceands.client.storybook.StorybookActivity
 import br.com.useblu.oceands.client.ui.accordion.AccordionActivity
 import br.com.useblu.oceands.client.ui.alert.AlertActivity
 import br.com.useblu.oceands.client.ui.badges.BadgesActivity
 import br.com.useblu.oceands.client.ui.balance.BalanceActivity
 import br.com.useblu.oceands.client.ui.banner.BannerActivity
 import br.com.useblu.oceands.client.ui.blubalance.BluBalanceActivity
-import br.com.useblu.oceands.client.storybook.StorybookActivity
 import br.com.useblu.oceands.client.ui.bottomnavigation.BottomNavigationActivity
 import br.com.useblu.oceands.client.ui.buttons.ButtonsActivity
 import br.com.useblu.oceands.client.ui.cardbalance.CardBalanceActivity

--- a/gallery/README.md
+++ b/gallery/README.md
@@ -33,14 +33,19 @@ São 2×4×2×3 = **48 combinações** por plataforma. As listas em `OceanBanner
 (`buildBannerMatrix`) e `BannerSnapshotTests.swift` (`BannerSnapshotMatrix`) **devem ficar em sincronia**.
 `title`/`description` são fixos (presets) — texto livre só num render ao vivo.
 
-## Publicar (CI)
+## Ver a galeria (CI → artifact baixável, sem admin/Pages)
 
-1. Em **Settings > Pages**, selecione **Source: GitHub Actions** (uma vez).
-2. Rode o workflow **Banner Storybook Gallery** (`Actions` > Run workflow), ou faça push nas paths monitoradas.
-3. Ao fim, o link do Pages aparece no job `publish` (`environment: github-pages`).
+O GitHub Pages exige admin do repo (token do CI não habilita nesta org), então a galeria
+sai como **artifact**:
 
-> O job iOS roda em runner macOS e faz checkout do `ocean-ds/ocean-ios` na branch `feat/ocean-banner-component`.
-> Ajuste a `ref` quando o Banner for mergeado em `main`/`develop`.
+1. Push nas paths monitoradas (ou `Actions` > Run workflow) dispara **Banner Storybook Gallery**.
+2. Ao fim do run, em **Artifacts**, baixe **`banner-gallery`**.
+3. Descompacte e abra **`gallery/index.html`** no navegador. Mexa nos knobs — cada combinação
+   mostra o PNG real de iOS e Android lado a lado.
+
+> O job iOS roda em runner macOS, faz checkout do `ocean-ds/ocean-ios` (branch `feat/ocean-banner-storybook`,
+> em pasta `ocean-ios`) e roda o test target do Swift Package via `xcodebuild test -scheme Ocean-Package`.
+> Se um dia houver admin, dá pra trocar o passo de artifact por deploy no GitHub Pages.
 
 ## Gerar localmente (quem tem o toolchain)
 

--- a/gallery/README.md
+++ b/gallery/README.md
@@ -46,7 +46,8 @@ São 2×4×2×3 = **48 combinações** por plataforma. As listas em `OceanBanner
 
 ```bash
 # Android → ocean-android/ocean-components/build/outputs/banner-snapshots/*.png
-./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
+# (o gerador só roda com a env var; sem ela é skipado, pra não pesar no CI padrão)
+BANNER_SNAPSHOT_GENERATE=true ./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
 cp ocean-components/build/outputs/banner-snapshots/*.png gallery/images/android/
 
 # iOS → ocean-ios/OceanDesignSystemTests/__BannerSnapshots__/*.png

--- a/gallery/README.md
+++ b/gallery/README.md
@@ -1,0 +1,73 @@
+# Banner Storybook Gallery — render real via WebView
+
+Galeria web que mostra o **componente Banner nativo de verdade** (iOS + Android lado a lado),
+acessível por qualquer browser/WebView **sem ninguém precisar rodar Xcode ou Android Studio**.
+
+O render nativo acontece **uma vez, no CI**; a saída é um site estático de imagens + controles.
+
+## Como funciona
+
+```
+┌─ ocean-android ─ OceanBannerSnapshotTest.kt ─┐   renderiza OceanBanner real (Robolectric)
+│                                               ├─► PNG  banner__<key>.png
+└─ ocean-ios ───── BannerSnapshotTests.swift ──┘   renderiza OceanSwiftUI.Banner real (XCTest)
+
+        CI (banner-gallery.yml) coleta os PNGs ─► gallery/images/{android,ios}/<key>.png
+        e publica gallery/ no GitHub Pages ─────► abrir o link no browser/WebView
+```
+
+A galeria (`index.html`) tem os mesmos knobs do Storybook nativo (Size, Type, Image, Buttons).
+Cada combinação carrega o PNG real correspondente das duas plataformas.
+
+### Esquema de chave (contrato compartilhado)
+
+```
+banner__{size}__{type}__{image}__{buttons}
+  size    = large | small
+  type    = default | warning | negative | emphasys
+  image   = noimage | image
+  buttons = none | one | two
+```
+
+São 2×4×2×3 = **48 combinações** por plataforma. As listas em `OceanBannerSnapshotTest.kt`
+(`buildBannerMatrix`) e `BannerSnapshotTests.swift` (`BannerSnapshotMatrix`) **devem ficar em sincronia**.
+`title`/`description` são fixos (presets) — texto livre só num render ao vivo.
+
+## Publicar (CI)
+
+1. Em **Settings > Pages**, selecione **Source: GitHub Actions** (uma vez).
+2. Rode o workflow **Banner Storybook Gallery** (`Actions` > Run workflow), ou faça push nas paths monitoradas.
+3. Ao fim, o link do Pages aparece no job `publish` (`environment: github-pages`).
+
+> O job iOS roda em runner macOS e faz checkout do `ocean-ds/ocean-ios` na branch `feat/ocean-banner-component`.
+> Ajuste a `ref` quando o Banner for mergeado em `main`/`develop`.
+
+## Gerar localmente (quem tem o toolchain)
+
+```bash
+# Android → ocean-android/ocean-components/build/outputs/banner-snapshots/*.png
+./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"
+cp ocean-components/build/outputs/banner-snapshots/*.png gallery/images/android/
+
+# iOS → ocean-ios/OceanDesignSystemTests/__BannerSnapshots__/*.png
+#   (rode BannerSnapshotTests no Xcode, ou via xcodebuild)
+cp ../ocean-ios/OceanDesignSystemTests/__BannerSnapshots__/*.png gallery/images/android/../ios/
+
+# Visualizar a galeria
+cd gallery && python3 -m http.server 8080   # abrir http://localhost:8080
+```
+
+## Adicionar um novo componente
+
+1. Crie `<Componente>SnapshotTest.kt` / `<Componente>SnapshotTests.swift` espelhando a matriz.
+2. Use o mesmo esquema de chave `comp__dim1__dim2__...`.
+3. Adicione os knobs do componente em `index.html`.
+
+## Limitações honestas
+
+- **Não é interativo de verdade**: knobs = combinações pré-renderizadas; texto livre vira preset.
+  Interação total no browser exige um device rodando (ex.: Appetize).
+- **Robolectric (Android)** e o **render off-screen (iOS)** podem divergir minimamente de um device
+  físico (antialiasing/fontes). Mas é o **código real do componente** — divergências de layout, cor e
+  dimensão são fiéis (é justamente isso que esta galeria expõe, ao contrário de uma maquete HTML).
+- Versões/CI podem precisar de ajuste fino no primeiro run (ver notas no `.github/workflows/banner-gallery.yml`).

--- a/gallery/index.html
+++ b/gallery/index.html
@@ -1,0 +1,131 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Ocean Banner — Storybook (render real)</title>
+<style>
+  :root{
+    --brand:#0025E0; --light-pure:#FFFFFF; --light-up:#F3F5FE; --light-down:#E0E2EE;
+    --dark-pure:#0C0D14; --dark-up:#AAADC0; --dark-down:#67697A; --dark-deep:#393B47;
+    --font:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  }
+  *{box-sizing:border-box} body{margin:0;font-family:var(--font);color:var(--dark-pure);background:#EEF1F8}
+  .app{padding:24px 16px 48px}
+  .head{max-width:1080px;margin:0 auto 20px}
+  .head h1{font-size:22px;margin:0 0 4px;letter-spacing:-.01em}
+  .head p{margin:0;color:var(--dark-down);font-size:14px}
+  .badge{display:inline-block;font-size:11px;font-weight:700;color:var(--brand);background:var(--light-up);
+         border:1px solid var(--light-down);border-radius:999px;padding:3px 10px;margin-top:10px}
+  main{max-width:1080px;margin:0 auto;display:flex;gap:20px;flex-wrap:wrap;align-items:flex-start}
+  .panel{background:var(--light-pure);border:1px solid var(--light-down);border-radius:14px;
+         box-shadow:0 1px 2px rgba(12,13,20,.04),0 8px 24px rgba(12,13,20,.04)}
+  .canvas-wrap{flex:2 1 520px;min-width:320px;padding:20px}
+  .canvas-label{font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--dark-up);margin-bottom:12px}
+  .platforms{display:flex;gap:18px;flex-wrap:wrap}
+  .plat{flex:1 1 240px;min-width:240px}
+  .plat h3{font-size:12px;font-weight:700;margin:0 0 8px;color:var(--dark-down);display:flex;align-items:center;gap:6px}
+  .plat .dot{width:8px;height:8px;border-radius:50%;background:var(--brand)}
+  .frame{background:
+      radial-gradient(circle at 1px 1px, var(--light-down) 1px, transparent 0) 0 0/16px 16px, var(--light-pure);
+      border:1px dashed var(--light-down);border-radius:12px;padding:20px;min-height:160px;
+      display:flex;align-items:center;justify-content:center}
+  .frame img{max-width:100%;height:auto;border-radius:8px;display:block}
+  .frame .pending{color:var(--dark-up);font-size:12px;text-align:center;line-height:1.5}
+  .controls{flex:1 1 280px;min-width:260px;padding:20px}
+  .controls h2{font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--dark-up);margin:0 0 14px}
+  .ctrl{margin-bottom:16px}
+  .ctrl > label{display:block;font-size:12px;font-weight:600;color:var(--dark-down);margin-bottom:6px}
+  .seg{display:flex;gap:6px;flex-wrap:wrap}
+  .seg button{flex:1 1 auto;border:1px solid var(--light-down);background:var(--light-pure);color:var(--dark-down);
+              border-radius:8px;padding:8px 10px;font-size:12px;font-weight:600;cursor:pointer;font-family:var(--font)}
+  .seg button.active{background:var(--brand);border-color:var(--brand);color:#fff}
+  .keyline{margin-top:8px;font:11px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;color:var(--dark-down);
+           word-break:break-all;background:var(--light-up);border:1px solid var(--light-down);border-radius:6px;padding:6px 8px}
+  footer{max-width:1080px;margin:22px auto 0;color:var(--dark-down);font-size:12px;line-height:1.6}
+  footer code{background:var(--light-up);border:1px solid var(--light-down);border-radius:4px;padding:1px 5px;font-size:11px}
+  .note{background:var(--light-up);border:1px solid var(--light-down);border-radius:10px;padding:12px 14px;font-size:12px;line-height:1.5;margin-top:14px;color:var(--dark-down)}
+  @media(max-width:760px){ main{flex-direction:column} .canvas-wrap,.controls{width:100%} }
+</style>
+</head>
+<body>
+<div class="app">
+  <div class="head">
+    <h1>Ocean Banner — Storybook (render real)</h1>
+    <p>Cada combinação mostra o <strong>componente nativo de verdade</strong>, capturado em snapshot no CI (iOS via XCTest, Android via Robolectric). Divergências reais entre as plataformas aparecem aqui.</p>
+    <span class="badge">Render real · iOS × Android lado a lado · sem rodar nada local</span>
+  </div>
+
+  <main>
+    <section class="panel canvas-wrap">
+      <div class="canvas-label">CANVAS</div>
+      <div class="platforms">
+        <div class="plat">
+          <h3><span class="dot"></span> iOS — SwiftUI</h3>
+          <div class="frame"><img id="img-ios" alt="iOS Banner"><div class="pending" id="pending-ios" hidden></div></div>
+        </div>
+        <div class="plat">
+          <h3><span class="dot"></span> Android — Compose</h3>
+          <div class="frame"><img id="img-android" alt="Android Banner"><div class="pending" id="pending-android" hidden></div></div>
+        </div>
+      </div>
+      <div class="keyline" id="keyline"></div>
+    </section>
+
+    <aside class="panel controls">
+      <h2>CONTROLS</h2>
+      <div class="ctrl"><label>Size</label><div class="seg" id="seg-size"></div></div>
+      <div class="ctrl"><label>Type / Style</label><div class="seg" id="seg-type"></div></div>
+      <div class="ctrl"><label>Image</label><div class="seg" id="seg-image"></div></div>
+      <div class="ctrl"><label>Buttons</label><div class="seg" id="seg-buttons"></div></div>
+      <div class="note">Title e Description são fixos nesta galeria de snapshots (presets). Variações de texto livre só num render ao vivo (ex.: stream do app).</div>
+    </aside>
+  </main>
+
+  <footer>
+    <strong>Como é gerado:</strong> <code>OceanBannerSnapshotTest.kt</code> (Android) e <code>BannerSnapshotTests.swift</code> (iOS) renderizam o componente real e gravam <code>images/{android,ios}/&lt;key&gt;.png</code>. O CI monta esta página e publica no GitHub Pages.
+    <div class="note">Robolectric (Android) e o render off-screen (iOS) podem ter diferenças mínimas vs. device físico (antialiasing/fontes), mas é o <strong>código real do componente</strong> — divergências de layout, cor e dimensão são fiéis.</div>
+  </footer>
+</div>
+
+<script>
+  var state = { size:'large', type:'default', image:'image', buttons:'one' };
+  var DIMS = {
+    size:    [['large','Large'],['small','Small']],
+    type:    [['default','Default'],['warning','Warning'],['negative','Negative'],['emphasys','Emphasys']],
+    image:   [['noimage','None'],['image','Image']],
+    buttons: [['none','0'],['one','1'],['two','2']]
+  };
+
+  function key(){ return 'banner__'+state.size+'__'+state.type+'__'+state.image+'__'+state.buttons; }
+
+  function seg(id, dim){
+    var el = document.getElementById('seg-'+id); el.innerHTML='';
+    DIMS[dim].forEach(function(o){
+      var b=document.createElement('button');
+      b.textContent=o[1]; if(state[dim]===o[0]) b.className='active';
+      b.onclick=function(){ state[dim]=o[0]; render(); };
+      el.appendChild(b);
+    });
+  }
+
+  function setImg(plat){
+    var img=document.getElementById('img-'+plat);
+    var pending=document.getElementById('pending-'+plat);
+    var k=key();
+    img.onload=function(){ img.hidden=false; pending.hidden=true; };
+    img.onerror=function(){ img.hidden=true; pending.hidden=false;
+      pending.textContent='Snapshot pendente para esta combinação.\n('+k+'.png)'; };
+    img.hidden=true; pending.hidden=false; pending.textContent='Carregando…';
+    img.src='images/'+plat+'/'+k+'.png';
+  }
+
+  function render(){
+    seg('size','size'); seg('type','type'); seg('image','image'); seg('buttons','buttons');
+    document.getElementById('keyline').textContent = key();
+    setImg('ios'); setImg('android');
+  }
+  render();
+</script>
+</body>
+</html>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.7.0"
 junit = "1.3.0"
 ktlintGradle = "12.2.0"
 robolectric = "4.16.1"
+roborazzi = "1.64.0"
 uiautomator = "2.3.0"
 lifecycleViewModel = "2.10.0"
 constraintLayout = "2.2.1"
@@ -44,6 +45,8 @@ lifecycleViewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", ve
 androidKtx = { module = "androidx.core:core-ktx", version.ref = "androidCoreKtx" }
 androidAppCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidAppCompatVersion" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }
 skydoves-balloon = { module = "com.github.skydoves:balloon", version.ref = "skydovesBalloonVersion" }
 skydoves-balloon-compose = { module = "com.github.skydoves:balloon-compose", version.ref = "skydovesBalloonVersion" }
 skydovesLandscapist = { module = "com.github.skydoves:landscapist-glide", version.ref = "skydovesLandscapistVersion" }

--- a/ocean-components/build.gradle.kts
+++ b/ocean-components/build.gradle.kts
@@ -123,6 +123,15 @@ dependencies {
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
+    testImplementation(libs.roborazzi)
+    testImplementation(libs.roborazzi.compose)
+}
+
+// Roborazzi grava os PNGs (modo record) apenas ao gerar a galeria.
+tasks.withType<Test>().configureEach {
+    if (System.getenv("BANNER_SNAPSHOT_GENERATE") == "true") {
+        systemProperty("roborazzi.test.record", "true")
+    }
 }
 
 baselineProfile {

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/OceanBanner.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/OceanBanner.kt
@@ -191,9 +191,7 @@ private fun OceanBannerInfoContent(
     OceanTextNotBlank(
         text = description,
         style = OceanTextStyle.description.copy(
-            fontFamily = OceanFontFamily.BaseMedium,
-            color = style.getDescriptionColor(),
-            lineHeight = OceanFontSize.xxs * 1.5f
+            color = style.getDescriptionColor()
         )
     )
 
@@ -203,12 +201,38 @@ private fun OceanBannerInfoContent(
             horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
         ) {
             if (ctaTitle.isNotEmpty()) {
-                OceanButton(
-                    text = ctaTitle,
-                    onClick = onCtaClick,
-                    buttonStyle = style.getButtonStyle(),
-                    disabled = !ctaIsEnabled
-                )
+                val isEmphasys = style is OceanBannerStyle.Emphasys || style is OceanBannerStyle.Brand
+                if (isEmphasys) {
+                    // Primary branco sólido — interfaceLightPure + brandPrimaryPure text
+                    Button(
+                        onClick = onCtaClick,
+                        enabled = ctaIsEnabled,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = OceanColors.interfaceLightPure,
+                            contentColor = OceanColors.brandPrimaryPure,
+                            disabledContainerColor = OceanColors.interfaceLightDown,
+                            disabledContentColor = OceanColors.interfaceDarkUp
+                        ),
+                        contentPadding = PaddingValues(horizontal = OceanSpacing.xs, vertical = 0.dp),
+                        shape = OceanBorderRadius.Circle.allCorners.shape(),
+                        elevation = ButtonDefaults.buttonElevation(0.dp),
+                        modifier = Modifier.height(32.dp)
+                    ) {
+                        OceanText(
+                            text = ctaTitle,
+                            fontSize = OceanFontSize.xs,
+                            fontFamily = OceanFontFamily.BaseBold,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                } else {
+                    OceanButton(
+                        text = ctaTitle,
+                        onClick = onCtaClick,
+                        buttonStyle = style.getButtonStyle(),
+                        disabled = !ctaIsEnabled
+                    )
+                }
             }
             if (secondaryCtaTitle.isNotEmpty()) {
                 val isEmphasys = style is OceanBannerStyle.Emphasys || style is OceanBannerStyle.Brand

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/OceanBanner.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/banner/OceanBanner.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -106,7 +107,11 @@ private fun OceanBannerLarge(
     onSecondaryCtaClick: () -> Unit,
     secondaryCtaIsEnabled: Boolean
 ) = Column {
-    image?.View()
+    image?.View(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(190.dp)
+    )
     OceanBannerInfoContent(
         style = style,
         title = title,
@@ -191,7 +196,9 @@ private fun OceanBannerInfoContent(
     OceanTextNotBlank(
         text = description,
         style = OceanTextStyle.description.copy(
-            color = style.getDescriptionColor()
+            fontFamily = OceanFontFamily.BaseMedium,
+            color = style.getDescriptionColor(),
+            lineHeight = OceanFontSize.xxs * 1.5f
         )
     )
 
@@ -201,38 +208,12 @@ private fun OceanBannerInfoContent(
             horizontalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
         ) {
             if (ctaTitle.isNotEmpty()) {
-                val isEmphasys = style is OceanBannerStyle.Emphasys || style is OceanBannerStyle.Brand
-                if (isEmphasys) {
-                    // Primary branco sólido — interfaceLightPure + brandPrimaryPure text
-                    Button(
-                        onClick = onCtaClick,
-                        enabled = ctaIsEnabled,
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = OceanColors.interfaceLightPure,
-                            contentColor = OceanColors.brandPrimaryPure,
-                            disabledContainerColor = OceanColors.interfaceLightDown,
-                            disabledContentColor = OceanColors.interfaceDarkUp
-                        ),
-                        contentPadding = PaddingValues(horizontal = OceanSpacing.xs, vertical = 0.dp),
-                        shape = OceanBorderRadius.Circle.allCorners.shape(),
-                        elevation = ButtonDefaults.buttonElevation(0.dp),
-                        modifier = Modifier.height(32.dp)
-                    ) {
-                        OceanText(
-                            text = ctaTitle,
-                            fontSize = OceanFontSize.xs,
-                            fontFamily = OceanFontFamily.BaseBold,
-                            textAlign = TextAlign.Center
-                        )
-                    }
-                } else {
-                    OceanButton(
-                        text = ctaTitle,
-                        onClick = onCtaClick,
-                        buttonStyle = style.getButtonStyle(),
-                        disabled = !ctaIsEnabled
-                    )
-                }
+                OceanButton(
+                    text = ctaTitle,
+                    onClick = onCtaClick,
+                    buttonStyle = style.getButtonStyle(),
+                    disabled = !ctaIsEnabled
+                )
             }
             if (secondaryCtaTitle.isNotEmpty()) {
                 val isEmphasys = style is OceanBannerStyle.Emphasys || style is OceanBannerStyle.Brand

--- a/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
@@ -20,6 +20,7 @@ import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
 import br.com.useblu.oceands.utils.image.OceanImageProxy
 import java.io.File
 import java.io.FileOutputStream
+import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -47,6 +48,14 @@ class OceanBannerSnapshotTest(private val case: BannerCase) {
 
     @Test
     fun snapshot() {
+        // Gerador de snapshots para a galeria — inerte no CI padrão.
+        // A galeria (workflow_dispatch) roda com BANNER_SNAPSHOT_GENERATE=true.
+        Assume.assumeTrue(
+            "Gerador de snapshots desabilitado; defina BANNER_SNAPSHOT_GENERATE=true para gerar",
+            System.getenv("BANNER_SNAPSHOT_GENERATE") == "true"
+        )
+        compose.mainClock.autoAdvance = false
+
         compose.setContent {
             OceanTheme {
                 Box(

--- a/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
@@ -18,14 +18,14 @@ import br.com.useblu.oceands.components.compose.banner.OceanBanner
 import br.com.useblu.oceands.components.compose.banner.OceanBannerKind
 import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
 import br.com.useblu.oceands.utils.image.OceanImageProxy
+import java.io.File
+import java.io.FileOutputStream
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.GraphicsMode
-import java.io.File
-import java.io.FileOutputStream
 
 /**
  * Gera os snapshots PNG do componente REAL [OceanBanner] para a galeria web (Storybook
@@ -99,7 +99,7 @@ data class BannerCase(
     val image: String,
     val buttons: String
 ) {
-    val key: String get() = "banner__${size}__${type}__${image}__${buttons}"
+    val key: String get() = "banner__${size}__${type}__${image}__$buttons"
 
     override fun toString(): String = key
 

--- a/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
@@ -1,0 +1,148 @@
+package br.com.useblu.oceands.snapshot
+
+import android.graphics.Bitmap
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import br.com.useblu.oceands.R
+import br.com.useblu.oceands.components.compose.OceanTheme
+import br.com.useblu.oceands.components.compose.banner.OceanBanner
+import br.com.useblu.oceands.components.compose.banner.OceanBannerKind
+import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
+import br.com.useblu.oceands.utils.image.OceanImageProxy
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Gera os snapshots PNG do componente REAL [OceanBanner] para a galeria web (Storybook
+ * via WebView). Não é teste de regressão — é o gerador de imagens consumido pelo CI.
+ *
+ * Renderiza o componente de verdade via Robolectric + GraphicsMode.NATIVE, então quaisquer
+ * divergências reais de render aparecem nas imagens (ao contrário de uma maquete HTML).
+ *
+ * Saída: `build/outputs/banner-snapshots/<key>.png` (um arquivo por combinação da matriz).
+ * Chave compartilhada com o iOS: `banner__{size}__{type}__{image}__{buttons}`.
+ */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@Config(qualifiers = "w360dp-h920dp-xhdpi")
+class OceanBannerSnapshotTest(private val case: BannerCase) {
+
+    @get:Rule
+    val compose = createComposeRule()
+
+    @Test
+    fun snapshot() {
+        compose.setContent {
+            OceanTheme {
+                Box(
+                    modifier = Modifier
+                        .width(343.dp)
+                        .wrapContentHeight()
+                        .testTag(TAG)
+                ) {
+                    OceanBanner(
+                        modifier = Modifier.fillMaxWidth(),
+                        style = case.style(),
+                        kind = case.kind(),
+                        title = TITLE,
+                        description = DESCRIPTION,
+                        ctaTitle = case.primaryTitle(),
+                        onCtaClick = {},
+                        secondaryCtaTitle = case.secondaryTitle(),
+                        onSecondaryCtaClick = {}
+                    )
+                }
+            }
+        }
+
+        val bitmap = compose.onNodeWithTag(TAG).captureToImage().asAndroidBitmap()
+        val dir = File(
+            System.getProperty("banner.snapshot.outDir")
+                ?: "build/outputs/banner-snapshots"
+        )
+        dir.mkdirs()
+        FileOutputStream(File(dir, "${case.key}.png")).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+    }
+
+    companion object {
+        private const val TAG = "banner"
+        private const val TITLE = "Banner Title"
+        private const val DESCRIPTION = "This is a description for the banner component."
+
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+        fun cases(): List<Array<Any>> = buildBannerMatrix().map { arrayOf<Any>(it) }
+    }
+}
+
+/** Uma combinação da matriz de variantes do Banner. */
+data class BannerCase(
+    val size: String,
+    val type: String,
+    val image: String,
+    val buttons: String
+) {
+    val key: String get() = "banner__${size}__${type}__${image}__${buttons}"
+
+    override fun toString(): String = key
+
+    fun style(): OceanBannerStyle = when (type) {
+        "warning" -> OceanBannerStyle.Warning
+        "negative" -> OceanBannerStyle.Negative
+        "emphasys" -> OceanBannerStyle.Emphasys
+        else -> OceanBannerStyle.Neutral
+    }
+
+    private fun image(): OceanImageProxy? = if (image == "image") {
+        OceanImageProxy.Resource(resId = R.drawable.image_placeholder)
+    } else {
+        null
+    }
+
+    fun kind(): OceanBannerKind = if (size == "large") {
+        OceanBannerKind.Large(image = image())
+    } else {
+        OceanBannerKind.Small(image = image())
+    }
+
+    fun primaryTitle(): String = if (buttons == "none") "" else "Ação principal"
+
+    fun secondaryTitle(): String = if (buttons == "two") "Secundária" else ""
+}
+
+/** Matriz compartilhada com o iOS — mantenha as dimensões e a ordem em sincronia. */
+fun buildBannerMatrix(): List<BannerCase> {
+    val sizes = listOf("large", "small")
+    val types = listOf("default", "warning", "negative", "emphasys")
+    val images = listOf("noimage", "image")
+    val buttons = listOf("none", "one", "two")
+
+    val matrix = mutableListOf<BannerCase>()
+    for (size in sizes) {
+        for (type in types) {
+            for (image in images) {
+                for (button in buttons) {
+                    matrix.add(BannerCase(size, type, image, button))
+                }
+            }
+        }
+    }
+    return matrix
+}

--- a/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
@@ -1,9 +1,10 @@
 package br.com.useblu.oceands.snapshot
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import br.com.useblu.oceands.R
@@ -11,6 +12,8 @@ import br.com.useblu.oceands.components.compose.OceanTheme
 import br.com.useblu.oceands.components.compose.banner.OceanBanner
 import br.com.useblu.oceands.components.compose.banner.OceanBannerKind
 import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
+import br.com.useblu.oceands.ui.compose.OceanColors
+import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.utils.image.OceanImageProxy
 import com.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
@@ -54,8 +57,9 @@ class OceanBannerSnapshotTest(private val case: BannerCase) {
             OceanTheme {
                 Box(
                     modifier = Modifier
-                        .width(343.dp)
-                        .wrapContentHeight()
+                        .width(360.dp)
+                        .background(OceanColors.interfaceLightUp)
+                        .padding(OceanSpacing.xs)
                 ) {
                     OceanBanner(
                         modifier = Modifier.fillMaxWidth(),

--- a/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/snapshot/OceanBannerSnapshotTest.kt
@@ -1,16 +1,10 @@
 package br.com.useblu.oceands.snapshot
 
-import android.graphics.Bitmap
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asAndroidBitmap
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.captureToImage
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.unit.dp
 import br.com.useblu.oceands.R
 import br.com.useblu.oceands.components.compose.OceanTheme
@@ -18,10 +12,9 @@ import br.com.useblu.oceands.components.compose.banner.OceanBanner
 import br.com.useblu.oceands.components.compose.banner.OceanBannerKind
 import br.com.useblu.oceands.components.compose.banner.OceanBannerStyle
 import br.com.useblu.oceands.utils.image.OceanImageProxy
+import com.github.takahirom.roborazzi.captureRoboImage
 import java.io.File
-import java.io.FileOutputStream
 import org.junit.Assume
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
@@ -32,10 +25,11 @@ import org.robolectric.annotation.GraphicsMode
  * Gera os snapshots PNG do componente REAL [OceanBanner] para a galeria web (Storybook
  * via WebView). Não é teste de regressão — é o gerador de imagens consumido pelo CI.
  *
- * Renderiza o componente de verdade via Robolectric + GraphicsMode.NATIVE, então quaisquer
- * divergências reais de render aparecem nas imagens (ao contrário de uma maquete HTML).
+ * Usa Roborazzi (Robolectric + GraphicsMode.NATIVE) para renderizar o componente de verdade,
+ * então quaisquer divergências reais de render aparecem nas imagens.
  *
- * Saída: `build/outputs/banner-snapshots/<key>.png` (um arquivo por combinação da matriz).
+ * Inerte no CI padrão (Assume) — só roda com BANNER_SNAPSHOT_GENERATE=true.
+ * Saída: `build/outputs/banner-snapshots/<key>.png`.
  * Chave compartilhada com o iOS: `banner__{size}__{type}__{image}__{buttons}`.
  */
 @RunWith(ParameterizedRobolectricTestRunner::class)
@@ -43,26 +37,25 @@ import org.robolectric.annotation.GraphicsMode
 @Config(qualifiers = "w360dp-h920dp-xhdpi")
 class OceanBannerSnapshotTest(private val case: BannerCase) {
 
-    @get:Rule
-    val compose = createComposeRule()
-
     @Test
     fun snapshot() {
-        // Gerador de snapshots para a galeria — inerte no CI padrão.
-        // A galeria (workflow_dispatch) roda com BANNER_SNAPSHOT_GENERATE=true.
         Assume.assumeTrue(
             "Gerador de snapshots desabilitado; defina BANNER_SNAPSHOT_GENERATE=true para gerar",
             System.getenv("BANNER_SNAPSHOT_GENERATE") == "true"
         )
-        compose.mainClock.autoAdvance = false
 
-        compose.setContent {
+        val dir = File(
+            System.getProperty("banner.snapshot.outDir")
+                ?: "build/outputs/banner-snapshots"
+        )
+        dir.mkdirs()
+
+        captureRoboImage(File(dir, "${case.key}.png").path) {
             OceanTheme {
                 Box(
                     modifier = Modifier
                         .width(343.dp)
                         .wrapContentHeight()
-                        .testTag(TAG)
                 ) {
                     OceanBanner(
                         modifier = Modifier.fillMaxWidth(),
@@ -78,20 +71,9 @@ class OceanBannerSnapshotTest(private val case: BannerCase) {
                 }
             }
         }
-
-        val bitmap = compose.onNodeWithTag(TAG).captureToImage().asAndroidBitmap()
-        val dir = File(
-            System.getProperty("banner.snapshot.outDir")
-                ?: "build/outputs/banner-snapshots"
-        )
-        dir.mkdirs()
-        FileOutputStream(File(dir, "${case.key}.png")).use { out ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
-        }
     }
 
     companion object {
-        private const val TAG = "banner"
         private const val TITLE = "Banner Title"
         private const val DESCRIPTION = "This is a description for the banner component."
 


### PR DESCRIPTION
## Description

Adiciona uma estrutura de **Storybook** ao app de exemplo do Ocean Android para testar e validar componentes em isolamento, com controles (knobs) interativos — e um **pipeline de galeria web** que renderiza o componente real em snapshots, tornando o render visível por qualquer browser/WebView **sem precisar rodar Android Studio**.

Primeiro componente: **Banner** (`OceanBanner`).

### Mudanças
- **Storybook Compose interativo** em `app/.../client/storybook/` (engine `StorybookStory`/catálogo + `StorybookControls` + `StorybookActivity`), acessível pelo primeiro item da Home (**🎨 Storybook**).
- **Story do Banner** (`storybook/BannerStory.kt`): canvas isolado + knobs de Size, Style, Image, Title, Description e CTAs.
- **`OceanBannerSnapshotTest`** (`ocean-components/src/test/.../snapshot/`): renderiza o `OceanBanner` real via Robolectric + `captureToImage()` e gera 1 PNG por variante. Sem dependência nova. Esquema de chave compartilhado com o iOS: `banner__{size}__{type}__{image}__{buttons}`.
- **Galeria web** (`gallery/`): exibe os PNGs reais **iOS × Android lado a lado**, com os mesmos knobs.
- **CI** (`.github/workflows/banner-gallery.yml`): gera os snapshots (job Android + job iOS macOS) e publica a galeria no **GitHub Pages**.

> ⚠️ **Stacked PR**: depende do componente Banner — **base = `feat/ocean-banner-component`**. Rebasear para a branch principal quando o Banner for mergeado.
> Para o Pages funcionar: **Settings → Pages → Source = GitHub Actions**.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- **Storybook**: rodar o módulo `app` → Home → **🎨 Storybook** → **Banner** e mexer nos controles.
- **Snapshots**: `./gradlew :ocean-components:testDebugUnitTest --tests "br.com.useblu.oceands.snapshot.OceanBannerSnapshotTest"` → PNGs em `ocean-components/build/outputs/banner-snapshots/`.
- **Galeria**: ver `gallery/README.md` (rodar via CI ou local com `python3 -m http.server`).

⚠️ **Não compilado/rodado pelo autor** (ambiente sem JDK/Android SDK). Validar no primeiro build — em especial `captureToImage()` sob `@GraphicsMode(NATIVE)` e a task de teste com AGP 9.1.

## Screenshots (if appropriate):

_A adicionar após o primeiro build/snapshot (a própria galeria do CI serve como evidência visual)._
