### PR TITLE
feat(inline-text-list): suporte a divider e bold no valor ativo

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanInlineTextListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanInlineTextListItem.kt
@@ -91,6 +91,18 @@ fun OceanInlineTextListItemPreview() {
             )
             OceanInlineTextListItem(
                 item = OceanInlineTextList(
+                    label = "Label bold com newValue",
+                    value = "Value",
+                    newValue = "New Value",
+                    color = "colorStatusPositiveDeep",
+                    isBold = true
+                )
+            )
+            OceanInlineTextListItem(
+                item = OceanInlineTextList(isDivider = true)
+            )
+            OceanInlineTextListItem(
+                item = OceanInlineTextList(
                     label = "Label",
                     value = "Value",
                     color = "colorStatusNeutralDeep",
@@ -212,6 +224,11 @@ fun OceanInlineTextListItem(
         return
     }
 
+    if (item.isDivider) {
+        OceanDivider(modifier = modifier)
+        return
+    }
+
     Column(
         modifier = modifier
     ) {
@@ -262,7 +279,9 @@ fun OceanInlineTextListItem(
                         ?: OceanColors.interfaceDarkDown
                 }
 
-                val valueStyle = if (item.isBold == true) {
+                // Bold só no valor "ativo": quando há newValue, o `value` fica
+                // riscado e não deve ser bold (o bold vai para o newValue abaixo).
+                val valueStyle = if (item.isBold == true && item.newValue.isNullOrBlank()) {
                     OceanTextStyle.paragraph.copy(
                         fontFamily = OceanFontFamily.BaseBold
                     )
@@ -284,10 +303,16 @@ fun OceanInlineTextListItem(
                     val color = item.color?.let {
                         OceanColors.fromString(color = it)
                     }
+                    // newValue é o valor "ativo": pode ser bold quando isBold=true.
+                    val newValueStyle = if (item.isBold == true) {
+                        OceanTextStyle.paragraph.copy(
+                            fontFamily = OceanFontFamily.BaseBold
+                        )
+                    } else OceanTextStyle.paragraph
                     OceanText(
                         text = item.newValue,
                         color = color ?: Color.Unspecified,
-                        style = OceanTextStyle.paragraph,
+                        style = newValueStyle,
                         modifier = Modifier.padding(start = OceanSpacing.xxxs)
                     )
                 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanInlineTextList.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/model/OceanInlineTextList.kt
@@ -9,5 +9,6 @@ data class OceanInlineTextList(
     val icon: String? = null,
     val isBold: Boolean? = false,
     val isStrike: Boolean? = !newValue.isNullOrBlank(),
-    val strikethroughColor: String? = null
+    val strikethroughColor: String? = null,
+    val isDivider: Boolean = false
 )


### PR DESCRIPTION
## O que

Dois ajustes no `OceanInlineTextListItem` / `OceanInlineTextList`, usados no resumo do `OceanTransactionFooter`:

1. **Divider**: novo campo `OceanInlineTextList.isDivider`. Quando `true`, o item renderiza um `OceanDivider` em vez da linha label/value. Permite divisores no meio do resumo (ex.: separar custos do "Pague em").
2. **Bold no valor ativo**: o bold passa a respeitar o valor "ativo":
   - `value` fica bold apenas quando **não** há `newValue` (o valor riscado nunca fica bold);
   - `newValue` fica bold quando `isBold = true`.

## Por quê

Consumidores (apps PagBlu) precisam renderizar o resumo de `payment_options` com divisores entre grupos e com o valor ativo em negrito — hoje o componente não suporta divider e aplicava bold no valor riscado.

## Como testar

Preview `OceanInlineTextListItemPreview` atualizado com:
- item com `newValue` + `isBold = true` (newValue em negrito, value riscado regular);
- item com `isDivider = true` (renderiza divider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)