### PR TITLE
feat(typography): alinha tipografia XML ao Figma + token loose_android (MR-492)

### DIFF
--- a/ocean-components/src/main/res/values/missing_tokens.xml
+++ b/ocean-components/src/main/res/values/missing_tokens.xml
@@ -21,6 +21,10 @@
 
     <dimen name="ocean_line_height_tight_android" category="font-line-height">0.9</dimen>
     <dimen name="ocean_line_height_medium_android" category="font-line-height">0.92</dimen>
+    <!-- Calibrado para reproduzir o line-height 132% (loose) do Figma via lineSpacingMultiplier.
+         Valor inicial por interpolação entre medium_android (124%) e comfy_android (150%);
+         valor final a confirmar no smoke visual T6 (spec MR-492). -->
+    <dimen name="ocean_line_height_loose_android" category="font-line-height">0.95</dimen>
     <dimen name="ocean_line_height_comfy_android" category="font-line-height">1.0</dimen>
 
     <dimen name="shadow_level_1">1dp</dimen>

--- a/ocean-components/src/main/res/values/ocean_styles.xml
+++ b/ocean-components/src/main/res/values/ocean_styles.xml
@@ -14,7 +14,7 @@
 
     <style name="Ocean.Subtitle" parent="Widget.AppCompat.TextView">
         <item name="android:fontFamily">@font/font_family_base_regular</item>
-        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_medium_android</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
         <item name="android:textColor">@color/ocean_color_interface_dark_down</item>
     </style>
 
@@ -63,22 +63,44 @@
 
     <style name="Ocean.Heading.4">
         <item name="android:textSize">@dimen/ocean_font_size_xs</item>
-        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
     </style>
 
     <style name="Ocean.Heading.5">
         <item name="android:textSize">@dimen/ocean_font_size_xxs</item>
-        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
     </style>
 
 
     <!-- SUBTITLE -->
     <style name="Ocean.Subtitle.1">
-        <item name="android:textSize">@dimen/ocean_font_size_md</item>
+        <item name="android:textSize">@dimen/ocean_font_size_sm</item>
     </style>
 
     <style name="Ocean.Subtitle.2">
-        <item name="android:textSize">@dimen/ocean_font_size_sm</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xs</item>
+    </style>
+
+
+    <!-- EYEBROW -->
+    <!-- UPPERCASE por construção (textAllCaps); letterSpacing 0.18em = 18% (paridade com os
+         2.16sp/12sp do Compose); line-height comfy_android. Spec MR-492 (CA-05/CA-06). -->
+    <style name="Ocean.Eyebrow" parent="Widget.AppCompat.TextView">
+        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_comfy_android</item>
+        <item name="android:textColor">@color/ocean_color_interface_dark_deep</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xxxs</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:letterSpacing">0.18</item>
+    </style>
+
+
+    <!-- CAPTION BOLD -->
+    <style name="Ocean.CaptionBold" parent="Widget.AppCompat.TextView">
+        <item name="android:fontFamily">@font/font_family_base_medium</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_comfy_android</item>
+        <item name="android:textColor">@color/ocean_color_interface_dark_down</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xxxs</item>
     </style>
 
 


### PR DESCRIPTION
## Description

Alinha a camada **XML legada** do Ocean DS Android ao set **Desktop** do Figma (frame `12536-78180`), conforme a **Spec Técnica MR-492** ([issue #1096](https://github.com/ocean-ds/ocean-android/issues/1096) · Jira [MR-492](https://useblu.atlassian.net/browse/MR-492)). Esta PR cobre a tarefa **T4**. A camada **Compose** (T2/T3/T5) está na PR irmã **#1098**.

> Contexto **OQ-05** (resolvida na spec): a camada XML **ainda renderiza** em apps consumidores (o app da Blu ainda tem features em XML), então este esforço permanece necessário.

### `missing_tokens.xml`
- Cria **`ocean_line_height_loose_android`** (Opção A da §3.2) para reproduzir o line-height **132% (loose)** do Figma via `lineSpacingMultiplier`. Os estilos XML consomem os tokens **`*_android`** calibrados (não os ratios bare), porque `lineSpacingMultiplier` multiplica o line-spacing intrínseco da fonte — não é o ratio CSS. Valor inicial **`0.95`** (interpolação entre `medium_android`/124% e `comfy_android`/150%), **a calibrar no smoke T6**.

### `ocean_styles.xml`
- **`Ocean.Heading.4`/`.5`**: removem o override `font_family_base_bold` (passam a **herdar `extrabold`** da base `Ocean.Heading`) e adotam **`loose_android`** — **CA-01/CA-04**.
- **`Ocean.Subtitle`** (base): `medium_android` → **`loose_android`** — **CA-04**.
- **`Ocean.Subtitle.1`**: `24sp` (md) → **`20sp`** (sm) · **`Ocean.Subtitle.2`**: `20sp` (sm) → **`16sp`** (xs) — **CA-02**.
- Cria **`Ocean.Eyebrow`**: `base_bold` + `xxxs` + `comfy_android` + `textAllCaps=true` + `letterSpacing 0.18em` (UPPERCASE por construção; `0.18em` = paridade com os `2.16sp/12sp` do Compose) — **CA-05/CA-06**.
- Cria **`Ocean.CaptionBold`**: `base_medium` + `xxxs` + `comfy_android` — **CA-06**.

Correção **por construção** na fundação dos estilos: os 30+ layouts que herdam `Heading.4/.5` e `Subtitle.*` ficam corretos sem retoque individual (**CA-07**).

### Checks locais
- `./gradlew :ocean-components:lintDebug` ✅ (recursos novos resolvem: token `loose_android`, `Ocean.Eyebrow`, `Ocean.CaptionBold`).

> **Validação visual pendente (T6, humano):** renderizar os layouts XML afetados × frame `12536-78180` e **calibrar o valor final de `loose_android`** (≈0.95 é ponto de partida). Sem Paparazzi no repo, a validação é por smoke (OQ-04).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

_Pendente — smoke visual T6 (validação humana contra o Figma `12536-78180`, inclui calibração de `loose_android`)._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)