### PR TITLE
feat(typography): alinha tipografia ao Figma — Compose + XML (MR-492)

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanEyebrow.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanEyebrow.kt
@@ -4,17 +4,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import br.com.useblu.oceands.ui.compose.OceanColors
-import br.com.useblu.oceands.ui.compose.OceanFontFamily
-import br.com.useblu.oceands.ui.compose.OceanFontSize
+import br.com.useblu.oceands.ui.compose.OceanTextStyle
 
 @Preview
 @Composable
@@ -41,14 +37,13 @@ fun OceanEyebrow(
     modifier: Modifier = Modifier,
     textColor: Color = OceanColors.interfaceDarkDeep
 ) {
-    Text(
+    // Uppercase é garantido por construção aqui (no render), pois `TextStyle` não tem
+    // equivalente a "allCaps". Os demais tokens (família, tamanho, letter-spacing,
+    // line-height) vêm de `OceanTextStyle.eyebrow` — fonte única (§3.3 do spec MR-492).
+    OceanText(
         text = text.uppercase(),
-        style = TextStyle(
-            fontSize = OceanFontSize.xxs,
-            fontFamily = OceanFontFamily.BaseMedium,
-            color = textColor,
-            letterSpacing = 2.16.sp
-        ),
-        modifier = modifier
+        modifier = modifier,
+        color = textColor,
+        style = OceanTextStyle.eyebrow
     )
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/balance/OceanBalanceUtils.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/balance/OceanBalanceUtils.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.zIndex
 import br.com.useblu.oceands.components.compose.OceanBadge
 import br.com.useblu.oceands.components.compose.OceanBadgeSize
 import br.com.useblu.oceands.components.compose.OceanDivider
+import br.com.useblu.oceands.components.compose.OceanEyebrow
 import br.com.useblu.oceands.components.compose.OceanIcon
 import br.com.useblu.oceands.components.compose.OceanText
 import br.com.useblu.oceands.components.compose.OceanTextNotBlank
@@ -452,10 +453,9 @@ internal fun BadgesContent(
                         modifier = finalBoxModifier,
                         contentAlignment = Alignment.Center
                     ) {
-                        OceanText(
-                            text = acquirer.take(1).uppercase(),
-                            color = style.fallbackTextColor,
-                            style = OceanTextStyle.eyebrow
+                        OceanEyebrow(
+                            text = acquirer.take(1),
+                            textColor = style.fallbackTextColor
                         )
                     }
                 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/ui/compose/OceanTextStyle.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/ui/compose/OceanTextStyle.kt
@@ -7,8 +7,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -16,34 +17,50 @@ import androidx.compose.ui.unit.sp
 
 object OceanTextStyle {
 
+    // Necessário para que o `lineHeight` declarado bata com o "line-height" do Figma:
+    // remove o font padding legado e centraliza a folga da linha (OQ-03 / §3.1 do spec MR-492).
+    private val noFontPadding = PlatformTextStyle(includeFontPadding = false)
+    private val centeredLineHeight = LineHeightStyle(
+        alignment = LineHeightStyle.Alignment.Center,
+        trim = LineHeightStyle.Trim.None
+    )
+
     private val heading @Composable get() = TextStyle(
         color = OceanColors.interfaceDarkDeep,
-        fontFamily = OceanFontFamily.BaseExtraBold
+        fontFamily = OceanFontFamily.BaseExtraBold,
+        platformStyle = noFontPadding,
+        lineHeightStyle = centeredLineHeight
     )
 
     private val subtitle @Composable get() = TextStyle(
         color = OceanColors.interfaceDarkDown,
-        fontFamily = OceanFontFamily.BaseRegular
+        fontFamily = OceanFontFamily.BaseRegular,
+        platformStyle = noFontPadding,
+        lineHeightStyle = centeredLineHeight
     )
 
-    val eyebrow @Composable get() = TextStyle(
+    private val body @Composable get() = TextStyle(
         color = OceanColors.interfaceDarkDown,
         fontFamily = OceanFontFamily.BaseRegular,
-        fontWeight = FontWeight(700),
+        platformStyle = noFontPadding,
+        lineHeightStyle = centeredLineHeight
+    )
+
+    val eyebrow @Composable get() = body.copy(
+        fontFamily = OceanFontFamily.BaseBold,
         fontSize = OceanFontSize.xxxs,
-        letterSpacing = 2.16.sp
+        letterSpacing = 2.16.sp,
+        lineHeight = OceanFontSize.xxxs * 1.5f
     )
 
-    val paragraph @Composable get() = TextStyle(
-        color = OceanColors.interfaceDarkDown,
-        fontFamily = OceanFontFamily.BaseRegular,
-        fontSize = OceanFontSize.xs
+    val paragraph @Composable get() = body.copy(
+        fontSize = OceanFontSize.xs,
+        lineHeight = OceanFontSize.xs * 1.5f
     )
 
-    val description @Composable get() = TextStyle(
-        color = OceanColors.interfaceDarkDown,
-        fontFamily = OceanFontFamily.BaseRegular,
-        fontSize = OceanFontSize.xxs
+    val description @Composable get() = body.copy(
+        fontSize = OceanFontSize.xxs,
+        lineHeight = OceanFontSize.xxs * 1.5f
     )
 
     val descriptionStrike @Composable get() = TextStyle(
@@ -65,39 +82,42 @@ object OceanTextStyle {
         fontSize = OceanFontSize.xxxs
     )
 
-    val caption @Composable get() = TextStyle(
-        color = OceanColors.interfaceDarkDown,
-        fontFamily = OceanFontFamily.BaseRegular,
-        fontSize = OceanFontSize.xxxs
+    val caption @Composable get() = body.copy(
+        fontSize = OceanFontSize.xxxs,
+        lineHeight = OceanFontSize.xxxs * 1.5f
     )
 
-    val captionBold @Composable get() = TextStyle(
-        color = OceanColors.interfaceDarkDown,
+    val captionBold @Composable get() = body.copy(
         fontFamily = OceanFontFamily.BaseMedium,
-        fontSize = OceanFontSize.xxxs
+        fontSize = OceanFontSize.xxxs,
+        lineHeight = OceanFontSize.xxxs * 1.5f
     )
 
-    val lead @Composable get() = TextStyle(
+    val lead @Composable get() = body.copy(
         color = OceanColors.interfaceDarkDeep,
         fontFamily = OceanFontFamily.BaseBold,
-        fontSize = OceanFontSize.sm
+        fontSize = OceanFontSize.sm,
+        lineHeight = OceanFontSize.sm * 1.5f
     )
 
     val heading1 @Composable get() = heading.copy(
-        fontSize = OceanFontSize.lg
+        fontSize = OceanFontSize.lg,
+        lineHeight = OceanFontSize.lg * 1.24f
     )
 
     val heading2 @Composable get() = heading.copy(
-        fontSize = OceanFontSize.md
+        fontSize = OceanFontSize.md,
+        lineHeight = OceanFontSize.md * 1.24f
     )
 
     val heading3 @Composable get() = heading.copy(
-        fontSize = OceanFontSize.sm
+        fontSize = OceanFontSize.sm,
+        lineHeight = OceanFontSize.sm * 1.24f
     )
 
     val heading4 @Composable get() = heading.copy(
         fontSize = OceanFontSize.xs,
-        fontFamily = OceanFontFamily.BaseBold
+        lineHeight = OceanFontSize.xs * 1.32f
     )
 
     val heading4Strike @Composable get() = heading.copy(
@@ -107,15 +127,18 @@ object OceanTextStyle {
     )
 
     val heading5 @Composable get() = heading4.copy(
-        fontSize = OceanFontSize.xxs
+        fontSize = OceanFontSize.xxs,
+        lineHeight = OceanFontSize.xxs * 1.32f
     )
 
     val subtitle1 @Composable get() = subtitle.copy(
-        fontSize = OceanFontSize.md
+        fontSize = OceanFontSize.sm,
+        lineHeight = OceanFontSize.sm * 1.32f
     )
 
     val subtitle2 @Composable get() = subtitle.copy(
-        fontSize = OceanFontSize.sm
+        fontSize = OceanFontSize.xs,
+        lineHeight = OceanFontSize.xs * 1.32f
     )
 
     val display @Composable get() = TextStyle(

--- a/ocean-components/src/main/res/values/missing_tokens.xml
+++ b/ocean-components/src/main/res/values/missing_tokens.xml
@@ -21,6 +21,10 @@
 
     <dimen name="ocean_line_height_tight_android" category="font-line-height">0.9</dimen>
     <dimen name="ocean_line_height_medium_android" category="font-line-height">0.92</dimen>
+    <!-- Calibrado para reproduzir o line-height 132% (loose) do Figma via lineSpacingMultiplier.
+         Valor inicial por interpolação entre medium_android (124%) e comfy_android (150%);
+         valor final a confirmar no smoke visual T6 (spec MR-492). -->
+    <dimen name="ocean_line_height_loose_android" category="font-line-height">0.95</dimen>
     <dimen name="ocean_line_height_comfy_android" category="font-line-height">1.0</dimen>
 
     <dimen name="shadow_level_1">1dp</dimen>

--- a/ocean-components/src/main/res/values/ocean_styles.xml
+++ b/ocean-components/src/main/res/values/ocean_styles.xml
@@ -14,7 +14,7 @@
 
     <style name="Ocean.Subtitle" parent="Widget.AppCompat.TextView">
         <item name="android:fontFamily">@font/font_family_base_regular</item>
-        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_medium_android</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
         <item name="android:textColor">@color/ocean_color_interface_dark_down</item>
     </style>
 
@@ -63,22 +63,44 @@
 
     <style name="Ocean.Heading.4">
         <item name="android:textSize">@dimen/ocean_font_size_xs</item>
-        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
     </style>
 
     <style name="Ocean.Heading.5">
         <item name="android:textSize">@dimen/ocean_font_size_xxs</item>
-        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_loose_android</item>
     </style>
 
 
     <!-- SUBTITLE -->
     <style name="Ocean.Subtitle.1">
-        <item name="android:textSize">@dimen/ocean_font_size_md</item>
+        <item name="android:textSize">@dimen/ocean_font_size_sm</item>
     </style>
 
     <style name="Ocean.Subtitle.2">
-        <item name="android:textSize">@dimen/ocean_font_size_sm</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xs</item>
+    </style>
+
+
+    <!-- EYEBROW -->
+    <!-- UPPERCASE por construção (textAllCaps); letterSpacing 0.18em = 18% (paridade com os
+         2.16sp/12sp do Compose); line-height comfy_android. Spec MR-492 (CA-05/CA-06). -->
+    <style name="Ocean.Eyebrow" parent="Widget.AppCompat.TextView">
+        <item name="android:fontFamily">@font/font_family_base_bold</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_comfy_android</item>
+        <item name="android:textColor">@color/ocean_color_interface_dark_deep</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xxxs</item>
+        <item name="android:textAllCaps">true</item>
+        <item name="android:letterSpacing">0.18</item>
+    </style>
+
+
+    <!-- CAPTION BOLD -->
+    <style name="Ocean.CaptionBold" parent="Widget.AppCompat.TextView">
+        <item name="android:fontFamily">@font/font_family_base_medium</item>
+        <item name="android:lineSpacingMultiplier">@dimen/ocean_line_height_comfy_android</item>
+        <item name="android:textColor">@color/ocean_color_interface_dark_down</item>
+        <item name="android:textSize">@dimen/ocean_font_size_xxxs</item>
     </style>
 
 

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanEyebrowTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanEyebrowTest.kt
@@ -1,0 +1,34 @@
+package br.com.useblu.oceands.components.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OceanEyebrowTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun rendersLowercaseTextInUpperCase() {
+        composeTestRule.setContent {
+            OceanEyebrow(text = "categoria")
+        }
+
+        composeTestRule.onNodeWithText("CATEGORIA").assertIsDisplayed()
+    }
+
+    @Test
+    fun isIdempotentWhenTextIsAlreadyUpperCase() {
+        composeTestRule.setContent {
+            OceanEyebrow(text = "DESTAQUE")
+        }
+
+        composeTestRule.onNodeWithText("DESTAQUE").assertIsDisplayed()
+    }
+}

--- a/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/OceanTextStyleTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/ui/compose/OceanTextStyleTest.kt
@@ -1,0 +1,106 @@
+package br.com.useblu.oceands.ui.compose
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OceanTextStyleTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private class Resolved {
+        lateinit var heading4: TextStyle
+        lateinit var heading5: TextStyle
+        lateinit var subtitle1: TextStyle
+        lateinit var subtitle2: TextStyle
+        lateinit var eyebrow: TextStyle
+        lateinit var paragraph: TextStyle
+        lateinit var caption: TextStyle
+        lateinit var lead: TextStyle
+        lateinit var baseExtraBold: FontFamily
+        lateinit var baseBold: FontFamily
+        var xxxs: TextUnit = TextUnit.Unspecified
+        var xxs: TextUnit = TextUnit.Unspecified
+        var xs: TextUnit = TextUnit.Unspecified
+        var sm: TextUnit = TextUnit.Unspecified
+    }
+
+    private fun resolveStyles(): Resolved {
+        val resolved = Resolved()
+        composeTestRule.setContent {
+            resolved.heading4 = OceanTextStyle.heading4
+            resolved.heading5 = OceanTextStyle.heading5
+            resolved.subtitle1 = OceanTextStyle.subtitle1
+            resolved.subtitle2 = OceanTextStyle.subtitle2
+            resolved.eyebrow = OceanTextStyle.eyebrow
+            resolved.paragraph = OceanTextStyle.paragraph
+            resolved.caption = OceanTextStyle.caption
+            resolved.lead = OceanTextStyle.lead
+            resolved.baseExtraBold = OceanFontFamily.BaseExtraBold
+            resolved.baseBold = OceanFontFamily.BaseBold
+            resolved.xxxs = OceanFontSize.xxxs
+            resolved.xxs = OceanFontSize.xxs
+            resolved.xs = OceanFontSize.xs
+            resolved.sm = OceanFontSize.sm
+        }
+        composeTestRule.waitForIdle()
+        return resolved
+    }
+
+    @Test
+    fun heading4IsExtraBoldSizeXsWithLooseLineHeight() {
+        val styles = resolveStyles()
+
+        assertEquals(styles.baseExtraBold, styles.heading4.fontFamily)
+        assertEquals(styles.xs, styles.heading4.fontSize)
+        assertEquals(styles.xs * 1.32f, styles.heading4.lineHeight)
+    }
+
+    @Test
+    fun heading5InheritsExtraBoldFromHeading4() {
+        val styles = resolveStyles()
+
+        assertEquals(styles.baseExtraBold, styles.heading5.fontFamily)
+        assertEquals(styles.xxs, styles.heading5.fontSize)
+        assertEquals(styles.xxs * 1.32f, styles.heading5.lineHeight)
+    }
+
+    @Test
+    fun subtitlesUseCorrectedSizesAndLineHeight() {
+        val styles = resolveStyles()
+
+        assertEquals(styles.sm, styles.subtitle1.fontSize)
+        assertEquals(styles.xs, styles.subtitle2.fontSize)
+        assertEquals(styles.sm * 1.32f, styles.subtitle1.lineHeight)
+        assertEquals(styles.xs * 1.32f, styles.subtitle2.lineHeight)
+    }
+
+    @Test
+    fun eyebrowIsBoldTwelveSpWithLetterSpacingAndLineHeight() {
+        val styles = resolveStyles()
+
+        assertEquals(styles.baseBold, styles.eyebrow.fontFamily)
+        assertEquals(styles.xxxs, styles.eyebrow.fontSize)
+        assertEquals(2.16.sp, styles.eyebrow.letterSpacing)
+        assertEquals(styles.xxxs * 1.5f, styles.eyebrow.lineHeight)
+    }
+
+    @Test
+    fun bodyVariantsDeclareLineHeight() {
+        val styles = resolveStyles()
+
+        assertNotEquals(TextUnit.Unspecified, styles.paragraph.lineHeight)
+        assertNotEquals(TextUnit.Unspecified, styles.caption.lineHeight)
+        assertNotEquals(TextUnit.Unspecified, styles.lead.lineHeight)
+    }
+}


### PR DESCRIPTION
## Description

Alinha o sistema tipográfico do Ocean DS Android ao set **Desktop** do Figma (frame `12536-78180`) nas **duas camadas em uso — Compose e XML legado** —, conforme a **Spec Técnica MR-492** ([issue #1096](https://github.com/ocean-ds/ocean-android/issues/1096) · Jira [MR-492](https://useblu.atlassian.net/browse/MR-492)). Correção **por construção** na fundação dos estilos: os 30+ componentes/layouts que herdam as variantes ficam corretos sem retoque individual.

Cobre as tarefas **T2** (Compose `OceanTextStyle`), **T3** (consolidação do eyebrow), **T4** (XML + token) e **T5** (testes) do plano da spec. Dois commits separam Compose e XML para facilitar a revisão.

### Compose — `OceanTextStyle.kt`, `OceanEyebrow.kt`, `OceanBalanceUtils.kt`
- **heading4/heading5**: peso `BaseExtraBold` (remove o override `BaseBold` de heading4; heading5 herda via heading4) — **CA-01**.
- **subtitle1**: `20sp` (sm) · **subtitle2**: `16sp` (xs) — **CA-02**.
- **lineHeight** declarado nas **13 variantes canônicas** (heading `1.24`/`1.32`, subtitle `1.32`, corpo `1.5`), derivado do `fontSize` por multiplicador (sem valor mágico) — **CA-03**.
- `platformStyle(includeFontPadding = false)` + `LineHeightStyle` nos estilos-base (`heading`/`subtitle`/`body`) — sem isso o `lineHeight` não bate com o "line-height" do Figma (**OQ-03**).
- **Eyebrow consolidado** (**OQ-02 / CA-05**): `OceanTextStyle.eyebrow` corrigido para o canônico (`BaseBold` + `12sp` + `letterSpacing 2.16sp` + `lineHeight`, removendo o `FontWeight(700)` sobre `BaseRegular` que gerava *fake bold*); `OceanEyebrow` passa a **consumir** esse style (fonte única) e só adiciona `.uppercase()` no render — única forma de garantir UPPERCASE por construção, já que `TextStyle` não tem "allCaps". Call-site de produção `OceanBalanceUtils.kt` migrado para `OceanEyebrow(...)`.

### XML — `ocean_styles.xml` + `missing_tokens.xml`
- Cria **`ocean_line_height_loose_android`** (Opção A da §3.2) para reproduzir o line-height **132% (loose)** via `lineSpacingMultiplier` (os estilos usam os tokens **`*_android`** calibrados, não os ratios bare). Valor inicial **`0.95`**, **a calibrar no smoke T6** — **CA-04**.
- **`Ocean.Heading.4`/`.5`**: removem o override `font_family_base_bold` (herdam `extrabold` da base) e adotam `loose_android` — **CA-01/CA-04**.
- **`Ocean.Subtitle`** (base): `medium_android` → `loose_android`; **`Subtitle.1`** `24→20sp`, **`Subtitle.2`** `20→16sp` — **CA-02/CA-04**.
- Cria **`Ocean.Eyebrow`** (`base_bold`, `xxxs`, `comfy_android`, `textAllCaps=true`, `letterSpacing 0.18em`) e **`Ocean.CaptionBold`** (`base_medium`, `xxxs`, `comfy_android`) — **CA-05/CA-06**.

### Testes (T5)
- `OceanTextStyleTest`: resolve família/tamanho/lineHeight de heading4/5, subtitles e eyebrow + herança de heading5 (Robolectric + Compose).
- `OceanEyebrowTest`: renderiza UPPERCASE a partir de minúsculo e é idempotente com texto já em caixa alta.

### Fora de escopo (mantidos)
`display`, `display2`, `error`, `hint`, `heading4Strike`, `descriptionStrike`.

### Checks locais (critérios de pronto da spec)
- `./gradlew :ocean-components:ktlintCheck` ✅
- `./gradlew :ocean-components:lintDebug` ✅
- `./gradlew :ocean-components:testDebugUnitTest` (OceanTextStyleTest + OceanEyebrowTest) → **7/7 verdes** ✅

> **Pendências humanas da spec:** **T6** — smoke visual no `:playground` (13 variantes Compose) + layouts XML afetados × frame `12536-78180`, **calibrando o valor final de `loose_android`** (não há Paparazzi no repo — OQ-04). **T7** — comunicar squads consumidoras sobre o UPPERCASE por construção do eyebrow.
>
> Contexto **OQ-05** (resolvida na spec): a camada XML ainda renderiza em apps consumidores, então o esforço XML é necessário.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots (if appropriate):

_Pendente — smoke visual T6 (validação humana contra o Figma `12536-78180`, inclui calibração de `loose_android`)._

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="544" height="1128" alt="image" src="https://github.com/user-attachments/assets/f655c700-2ea4-4199-a2e1-24e13616a333" />
<img width="566" height="1130" alt="image" src="https://github.com/user-attachments/assets/488b9411-f6a1-4445-a977-20e957d872bf" />
<img width="556" height="1154" alt="image" src="https://github.com/user-attachments/assets/0d2814c2-5ac7-4c36-b346-3b8f8c7f3a32" />
<img width="570" height="1144" alt="image" src="https://github.com/user-attachments/assets/488e4216-33bd-4a92-bbe6-b0aff9d6ba82" />
<img width="564" height="1146" alt="image" src="https://github.com/user-attachments/assets/8b423d43-7e85-4760-b19f-93cadcc44996" />
