### PR TITLE
fix(OceanCarousel): avoid stale index crash in auto-cycle effect

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanCarousel.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanCarousel.kt
@@ -86,15 +86,13 @@ fun OceanCarousel(
         pageCount = { items.size }
     )
 
-    LaunchedEffect(key1 = autoCycle) {
-        if (autoCycle) {
+    LaunchedEffect(key1 = autoCycle, key2 = items) {
+        if (autoCycle && items.isNotEmpty()) {
             while (true) {
-                runCatching {
-                    delay(autoCycleTime)
-                    pagerState.animateScrollToPage(
-                        page = (pagerState.currentPage + 1) % items.size
-                    )
-                }
+                delay(autoCycleTime)
+                pagerState.animateScrollToPage(
+                    page = (pagerState.currentPage + 1) % items.size
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- `OceanCarousel`'s auto-cycle `LaunchedEffect` only restarted when `autoCycle` toggled, so a running coroutine kept using a stale `items` list captured at launch.
- If `items` shrank between cycles (e.g. backend/remote-config-driven banners), `(currentPage + 1) % items.size` computed an index no longer valid for the pager's current `pageCount`, crashing with `IndexOutOfBoundsException: Index N, size N` during Compose's measure pass — matches a production Crashlytics crash on the Home banner carousel.
- Fix: key the effect on `items` as well so it restarts (cancelling the stale coroutine) whenever the list changes, and guard against an empty list. Also dropped the `runCatching` wrapper since it didn't actually protect against this crash (the exception surfaces on the next frame's measure/draw, not synchronously inside the wrapped block).

## Test plan
- [x] Verify `OceanCarouselPreview` still renders/auto-cycles correctly in Compose preview
- [x] Manual repro: render `OceanCarousel` with `autoCycle = true`, then shrink the `items` list mid-cycle and confirm no crash and auto-cycle continues correctly with the new size
- [x] CI (ktlint / unit tests) green

## Screenshot

https://github.com/user-attachments/assets/d98dd03e-8148-447a-af18-04a651e6c4f6

https://github.com/user-attachments/assets/7c54a3c1-7adc-49ea-823d-f4fe921f905c

🤖 Generated with [Claude Code](https://claude.com/claude-code)