### PR TITLE
feat: add Highlight variant to OceanTransactionFooter

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
@@ -12,11 +12,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import br.com.useblu.oceands.model.OceanInlineTextList
+import br.com.useblu.oceands.ui.compose.OceanBorderRadius
 import br.com.useblu.oceands.ui.compose.OceanButtonStyle
 import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.ui.compose.OceanTextStyle
+import br.com.useblu.oceands.ui.compose.borderBackground
 import br.com.useblu.oceands.utils.OceanIcons
+
+enum class OceanTransactionFooterVariant {
+    Default,
+    Highlight
+}
 
 @Composable
 fun OceanTransactionFooter(
@@ -26,11 +33,23 @@ fun OceanTransactionFooter(
     secondButton: OceanButtonModel? = null,
     entriesSpacing: Dp = OceanSpacing.xxs,
     buttonsOrientation: Orientation = Orientation.Vertical,
-    caption: String = ""
+    caption: String = "",
+    variant: OceanTransactionFooterVariant = OceanTransactionFooterVariant.Default
 ) {
+    val backgroundModifier = when (variant) {
+        OceanTransactionFooterVariant.Default ->
+            Modifier.background(OceanColors.interfaceLightPure)
+
+        OceanTransactionFooterVariant.Highlight ->
+            Modifier.borderBackground(
+                color = OceanColors.interfaceLightUp,
+                borderRadius = OceanBorderRadius.LG.topCorners
+            )
+    }
+
     Column(
         modifier = modifier
-            .background(OceanColors.interfaceLightPure)
+            .then(backgroundModifier)
             .padding(OceanSpacing.xs),
         verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
     ) {
@@ -155,6 +174,44 @@ private fun OceanTransactionFooterPreview() {
             ),
             buttonsOrientation = Orientation.Vertical,
             caption = "Lorem ipsum dolor sit amet, consectetur adipis"
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OceanTransactionFooterHighlightPreview() {
+    val entries = listOf(
+        OceanInlineTextList(
+            label = "Você vai economizar",
+            value = "R$ 40,00",
+            color = "colorStatusPositiveDeep",
+            icon = "tagsolid"
+        ),
+        OceanInlineTextList(
+            label = "Custo de antecipação",
+            value = "3,99%",
+            newValue = "Grátis",
+            color = "colorStatusPositiveDeep"
+        ),
+        OceanInlineTextList(
+            label = "Pagando",
+            value = "R$ 41.256,25",
+            color = "colorInterfaceDarkPure",
+            isBold = true
+        )
+    )
+
+    OceanTheme {
+        OceanTransactionFooter(
+            entries = entries,
+            firstButton = OceanButtonModel(
+                text = "Confirmar pagamento",
+                onClick = {},
+                buttonStyle = OceanButtonStyle.PrimaryMedium
+            ),
+            caption = "O valor pode variar conforme a data de compensação.",
+            variant = OceanTransactionFooterVariant.Highlight
         )
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
@@ -36,7 +36,9 @@ fun OceanTransactionFooter(
     entriesSpacing: Dp = OceanSpacing.xxs,
     buttonsOrientation: Orientation = Orientation.Vertical,
     caption: String = "",
-    variant: OceanTransactionFooterVariant = OceanTransactionFooterVariant.Default
+    variant: OceanTransactionFooterVariant = OceanTransactionFooterVariant.Default,
+    sectionTitle: String = "",
+    showBottomDivider: Boolean = false
 ) {
     val backgroundModifier = when (variant) {
         OceanTransactionFooterVariant.Default ->
@@ -76,7 +78,18 @@ fun OceanTransactionFooter(
             verticalArrangement = Arrangement.spacedBy(entriesSpacing),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            entries.forEach { item ->
+            OceanTextNotBlank(
+                text = sectionTitle,
+                modifier = Modifier.fillMaxWidth(),
+                color = OceanColors.interfaceDarkUp,
+                style = OceanTextStyle.heading5
+            )
+            entries.forEachIndexed { index, item ->
+                if (showBottomDivider && index == entries.lastIndex && index > 0) {
+                    OceanDivider(
+                        modifier = Modifier.padding(vertical = OceanSpacing.xxxs)
+                    )
+                }
                 OceanInlineTextListItem(
                     item = item
                 )
@@ -161,7 +174,9 @@ private fun OceanTransactionFooterPreview() {
                 onClick = {},
                 buttonStyle = OceanButtonStyle.PrimaryMedium
             ),
-            variant = OceanTransactionFooterVariant.Default
+            variant = OceanTransactionFooterVariant.Default,
+            sectionTitle = "Title",
+            showBottomDivider = true
         )
     }
 }
@@ -196,7 +211,9 @@ private fun OceanTransactionFooterHighlightPreview() {
                 onClick = {},
                 buttonStyle = OceanButtonStyle.PrimaryMedium
             ),
-            variant = OceanTransactionFooterVariant.Highlight
+            variant = OceanTransactionFooterVariant.Highlight,
+            sectionTitle = "Title",
+            showBottomDivider = true
         )
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanTransactionFooter.kt
@@ -9,8 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import br.com.useblu.oceands.model.OceanInlineTextList
 import br.com.useblu.oceands.ui.compose.OceanBorderRadius
 import br.com.useblu.oceands.ui.compose.OceanButtonStyle
@@ -18,7 +21,6 @@ import br.com.useblu.oceands.ui.compose.OceanColors
 import br.com.useblu.oceands.ui.compose.OceanSpacing
 import br.com.useblu.oceands.ui.compose.OceanTextStyle
 import br.com.useblu.oceands.ui.compose.borderBackground
-import br.com.useblu.oceands.utils.OceanIcons
 
 enum class OceanTransactionFooterVariant {
     Default,
@@ -47,9 +49,26 @@ fun OceanTransactionFooter(
             )
     }
 
+    // Divisor de topo da variante Default (Figma) — desenhado no topo, edge-to-edge,
+    // sem alterar o padding do conteúdo. A Highlight arredonda o topo e não tem divisor.
+    val dividerColor = OceanColors.interfaceLightDown
+    val topDividerModifier = if (variant == OceanTransactionFooterVariant.Default) {
+        Modifier.drawBehind {
+            drawLine(
+                color = dividerColor,
+                start = Offset(0f, 0f),
+                end = Offset(size.width, 0f),
+                strokeWidth = 1.dp.toPx()
+            )
+        }
+    } else {
+        Modifier
+    }
+
     Column(
         modifier = modifier
             .then(backgroundModifier)
+            .then(topDividerModifier)
             .padding(OceanSpacing.xs),
         verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
     ) {
@@ -117,86 +136,18 @@ fun OceanTransactionFooter(
 private fun OceanTransactionFooterPreview() {
     val entries = listOf(
         OceanInlineTextList(
-            label = "Label1",
-            value = "R$ 40,00",
-            newValue = "Zero",
-            color = "colorStatusPositiveDeep",
-            icon = "tagsolid"
-        ),
-        OceanInlineTextList(
-            label = "Label1 - teste",
-            value = "R$ 40,00",
-            newValue = "",
-            color = "colorStatusPositiveDeep"
-        ),
-        OceanInlineTextList(
-            label = "Label2",
-            value = "R$ 40,00",
+            label = "Title",
+            value = "Description",
             color = "colorInterfaceDarkDown"
-
         ),
         OceanInlineTextList(
-            label = "Label3",
-            value = "Calculada no dia",
-            color = "colorStatusNeutralDeep"
-
+            label = "Title",
+            value = "Description",
+            color = "colorInterfaceDarkDown"
         ),
         OceanInlineTextList(
-            label = "Label4",
-            value = "R$ 10,00",
-            tooltip = "tooltip",
-            color = "colorStatusPositiveDeep",
-            icon = "tagsolid"
-
-        ),
-        OceanInlineTextList(
-            label = "Label5",
-            value = "R$ 40,00",
-            color = "colorInterfaceDarkPure",
-            isBold = true,
-            icon = OceanIcons.BRIEFCASE_OUTLINE.token
-
-        )
-    )
-
-    OceanTheme {
-        OceanTransactionFooter(
-            entries = entries,
-            firstButton = OceanButtonModel(
-                text = "Avançar",
-                onClick = {},
-                buttonStyle = OceanButtonStyle.PrimaryMedium
-            ),
-            secondButton = OceanButtonModel(
-                text = "Voltar",
-                onClick = {},
-                buttonStyle = OceanButtonStyle.SecondaryMedium
-            ),
-            buttonsOrientation = Orientation.Vertical,
-            caption = "Lorem ipsum dolor sit amet, consectetur adipis"
-        )
-    }
-}
-
-@Preview
-@Composable
-private fun OceanTransactionFooterHighlightPreview() {
-    val entries = listOf(
-        OceanInlineTextList(
-            label = "Você vai economizar",
-            value = "R$ 40,00",
-            color = "colorStatusPositiveDeep",
-            icon = "tagsolid"
-        ),
-        OceanInlineTextList(
-            label = "Custo de antecipação",
-            value = "3,99%",
-            newValue = "Grátis",
-            color = "colorStatusPositiveDeep"
-        ),
-        OceanInlineTextList(
-            label = "Pagando",
-            value = "R$ 41.256,25",
+            label = "Title",
+            value = "Description",
             color = "colorInterfaceDarkPure",
             isBold = true
         )
@@ -206,11 +157,45 @@ private fun OceanTransactionFooterHighlightPreview() {
         OceanTransactionFooter(
             entries = entries,
             firstButton = OceanButtonModel(
-                text = "Confirmar pagamento",
+                text = "Label",
                 onClick = {},
                 buttonStyle = OceanButtonStyle.PrimaryMedium
             ),
-            caption = "O valor pode variar conforme a data de compensação.",
+            variant = OceanTransactionFooterVariant.Default
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OceanTransactionFooterHighlightPreview() {
+    val entries = listOf(
+        OceanInlineTextList(
+            label = "Title",
+            value = "Description",
+            color = "colorInterfaceDarkDown"
+        ),
+        OceanInlineTextList(
+            label = "Title",
+            value = "Description",
+            color = "colorInterfaceDarkDown"
+        ),
+        OceanInlineTextList(
+            label = "Title",
+            value = "Description",
+            color = "colorInterfaceDarkPure",
+            isBold = true
+        )
+    )
+
+    OceanTheme {
+        OceanTransactionFooter(
+            entries = entries,
+            firstButton = OceanButtonModel(
+                text = "Label",
+                onClick = {},
+                buttonStyle = OceanButtonStyle.PrimaryMedium
+            ),
             variant = OceanTransactionFooterVariant.Highlight
         )
     }

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanTransactionFooterTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanTransactionFooterTest.kt
@@ -1,0 +1,59 @@
+package br.com.useblu.oceands.components.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import br.com.useblu.oceands.model.OceanInlineTextList
+import br.com.useblu.oceands.ui.compose.OceanButtonStyle
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OceanTransactionFooterTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val entries = listOf(
+        OceanInlineTextList(
+            label = "Pagando",
+            value = "R$ 42,00",
+            color = "colorInterfaceDarkPure",
+            isBold = true
+        )
+    )
+
+    private val firstButton = OceanButtonModel(
+        text = "Continuar",
+        onClick = {},
+        buttonStyle = OceanButtonStyle.PrimaryMedium
+    )
+
+    @Test
+    fun whenVariantOmitted_rendersDefaultContent() {
+        composeTestRule.setContent {
+            OceanTransactionFooter(
+                entries = entries,
+                firstButton = firstButton
+            )
+        }
+
+        composeTestRule.onNodeWithText("Continuar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Pagando").assertIsDisplayed()
+    }
+
+    @Test
+    fun whenVariantHighlight_rendersContent() {
+        composeTestRule.setContent {
+            OceanTransactionFooter(
+                entries = entries,
+                firstButton = firstButton,
+                variant = OceanTransactionFooterVariant.Highlight
+            )
+        }
+
+        composeTestRule.onNodeWithText("Continuar").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Pagando").assertIsDisplayed()
+    }
+}

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanTransactionFooterTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanTransactionFooterTest.kt
@@ -56,4 +56,23 @@ class OceanTransactionFooterTest {
         composeTestRule.onNodeWithText("Continuar").assertIsDisplayed()
         composeTestRule.onNodeWithText("Pagando").assertIsDisplayed()
     }
+
+    @Test
+    fun whenSectionTitleAndBottomDivider_rendersHeaderAndEntries() {
+        composeTestRule.setContent {
+            OceanTransactionFooter(
+                entries = listOf(
+                    OceanInlineTextList(label = "Subtotal", value = "R$ 40,00"),
+                    OceanInlineTextList(label = "Total", value = "R$ 42,00", isBold = true)
+                ),
+                firstButton = firstButton,
+                sectionTitle = "Resumo",
+                showBottomDivider = true
+            )
+        }
+
+        composeTestRule.onNodeWithText("Resumo").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Subtotal").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Total").assertIsDisplayed()
+    }
 }


### PR DESCRIPTION
## Descrição

Adiciona a variante visual **`Highlight`** ao `OceanTransactionFooter` (Compose) e alinha o componente ao Figma do Ocean DS Core (node `25851-3910`). Mudança **aditiva** (novo parâmetro `variant` com default `Default`) + ajustes **somente de layout** (sem alterar props existentes, para não quebrar integrações atuais).

## Tipo de mudança

`feature`

## O que está sendo resolvido

- Parâmetro `variant` no `OceanTransactionFooter`, com a variante `Highlight` fiel ao Figma (fundo `interfaceLightUp` + cantos superiores 16dp).
- `Default` alinhada ao Figma: passa a exibir o **divisor de topo**.

## Como foi resolvido

- `OceanTransactionFooter.kt`:
  - Novo enum `OceanTransactionFooterVariant { Default, Highlight }` + parâmetro `variant = OceanTransactionFooterVariant.Default` (último da assinatura, retrocompatível por default do Kotlin).
  - **Default** → fundo `OceanColors.interfaceLightPure` + **divisor de topo** (`OceanColors.interfaceLightDown`, 1dp) desenhado no topo via `drawBehind`, edge-to-edge, **sem alterar o padding do conteúdo**.
  - **Highlight** → `borderBackground(interfaceLightUp, OceanBorderRadius.LG.topCorners)` — fundo destacado + cantos superiores 16dp, sem stroke, caixa externa idêntica (sem "pulo" de layout).
  - `@Preview` das 2 variantes com textos genéricos (Title / Description / Label).
- `OceanTransactionFooterTest.kt` — teste Robolectric + Compose das 2 variantes.

### Novas props opcionais (aditivas — não quebram integrações)

Para fidelidade completa ao Figma, foram adicionadas duas props opcionais com default que preserva o comportamento atual:

- `sectionTitle: String = ""` — quando preenchido, renderiza o **Section Header** acima das linhas (`OceanTextStyle.heading5` / `OceanColors.interfaceDarkUp`).
- `showBottomDivider: Boolean = false` — quando `true`, desenha um **divisor interno** (`OceanDivider`) antes da última linha (o "item bottom" / total).

Nenhuma prop existente foi alterada/removida; todos os defaults preservam o comportamento atual — as chamadas atuais **compilam e renderizam igual**. Compose-only: o binding adapter XML legado não recebe as novas props.

## Cenários de teste

Rodados localmente:

- ✅ `./gradlew :ocean-components:ktlintFormat :ocean-components:ktlintCheck` — BUILD SUCCESSFUL.
- ✅ `./gradlew :ocean-components:testDebugUnitTest --tests "*OceanTransactionFooterTest"` — BUILD SUCCESSFUL.

O reviewer deve validar via `@Preview` (Android Studio) que a `Default` exibe o divisor de topo e a `Highlight` mostra fundo `interfaceLightUp` + cantos superiores 16dp, contra o Figma (node `25851-3910`).

## Links

- **Jira:** [MR-514](https://useblu.atlassian.net/browse/MR-514)
- **Figma:** Ocean DS Core — node `25851-3910`

## Breaking changes

Sem quebra de API (parâmetro aditivo, nenhuma prop alterada). Observação: a `Default` passa a exibir um divisor de topo (mudança visual de alinhamento com o Figma).
