### PR TITLE
feat(card-list-item): adiciona ABOVE e BELOW ao tagAlignment

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
@@ -444,45 +444,6 @@ fun OceanCardListItemPreview() {
             )
 
             OceanCardListItem(
-                title = "Title with Tag Above",
-                description = "Description",
-                caption = "Caption",
-                tagStyle = OceanTagStyle.Default(
-                    label = "3x sem acréscimo",
-                    layout = OceanTagLayout.Medium(),
-                    type = OceanTagType.Positive
-                ),
-                tagAlignment = OceanCardListItemTagAlignment.ABOVE
-            )
-
-            OceanCardListItem(
-                title = "Title with Tag Below",
-                description = "Description",
-                caption = "Caption",
-                tagStyle = OceanTagStyle.Default(
-                    label = "3x sem acréscimo",
-                    layout = OceanTagLayout.Medium(),
-                    type = OceanTagType.Positive
-                ),
-                tagAlignment = OceanCardListItemTagAlignment.BELOW
-            )
-
-            OceanCardListItem(
-                title = "Selectable with Tag Above",
-                description = "Description",
-                tagStyle = OceanTagStyle.Default(
-                    label = "3x sem acréscimo",
-                    layout = OceanTagLayout.Medium(),
-                    type = OceanTagType.Positive
-                ),
-                tagAlignment = OceanCardListItemTagAlignment.ABOVE,
-                type = OceanCardListItemType.Selectable(
-                    selectionType = OceanCardListItemType.Selectable.SelectionType.Radiobutton,
-                    didUpdate = {}
-                )
-            )
-
-            OceanCardListItem(
                 title = "Title with Chevron",
                 description = "Description with chevron icon",
                 showChevron = true,
@@ -733,6 +694,75 @@ fun OceanCardListItemPreview() {
                     iconColor = OceanColors.statusPositiveDeep
                 ),
                 onClick = {}
+            )
+        }
+    }
+}
+
+/**
+ * As quatro posições de tag lado a lado (MR-554). START e END são o comportamento atual;
+ * ABOVE e BELOW empilham dentro do bloco de conteúdo, com 8dp de respiro.
+ */
+@Preview(showBackground = true, heightDp = 640)
+@Composable
+fun OceanCardListItemTagPositionPreview() {
+    val tag = OceanTagStyle.Default(
+        label = "3x sem acréscimo",
+        layout = OceanTagLayout.Medium(),
+        type = OceanTagType.Positive
+    )
+
+    OceanTheme {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(OceanColors.interfaceLightPure)
+                .padding(OceanSpacing.xs),
+            verticalArrangement = Arrangement.spacedBy(OceanSpacing.xs)
+        ) {
+            OceanCardListItem(
+                title = "START (default)",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.START
+            )
+
+            OceanCardListItem(
+                title = "END",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.END
+            )
+
+            OceanCardListItem(
+                title = "ABOVE",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE
+            )
+
+            OceanCardListItem(
+                title = "BELOW",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.BELOW
+            )
+
+            OceanCardListItem(
+                title = "ABOVE + radio (caso MR-523)",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE,
+                type = OceanCardListItemType.Selectable(
+                    selectionType = OceanCardListItemType.Selectable.SelectionType.Radiobutton,
+                    didUpdate = {}
+                ),
+                isSelected = true
             )
         }
     }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
@@ -50,10 +50,10 @@ import br.com.useblu.oceands.utils.OceanIcons
 import br.com.useblu.oceands.utils.vibrator.rememberVibrator
 
 /**
- * Onde a tag é posicionada em relação ao texto do card.
+ * Where the tag is positioned relative to the card text.
  *
- * [START] e [END] mantêm a tag na mesma linha do título; [ABOVE] e [BELOW] a empilham
- * dentro do bloco de conteúdo, nunca no slot do controle (radio/checkbox/chevron).
+ * [START] and [END] keep the tag on the same line as the title; [ABOVE] and [BELOW] stack it
+ * inside the content block, never in the control slot (radio/checkbox/chevron).
  */
 enum class OceanCardListItemTagAlignment {
     START,
@@ -282,7 +282,7 @@ private fun CenterContent(
             }
             OceanCardListItemTagAlignment.ABOVE,
             OceanCardListItemTagAlignment.BELOW -> {
-                // A tag é emitida fora da linha do título, acima ou abaixo do bloco de texto.
+                // The tag is emitted outside the title line, above or below the text block.
                 TitleWithTag(
                     title = title,
                     contentStyle = contentStyle,

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
@@ -49,9 +49,17 @@ import br.com.useblu.oceands.ui.compose.OceanTextStyle
 import br.com.useblu.oceands.utils.OceanIcons
 import br.com.useblu.oceands.utils.vibrator.rememberVibrator
 
+/**
+ * Onde a tag é posicionada em relação ao texto do card.
+ *
+ * [START] e [END] mantêm a tag na mesma linha do título; [ABOVE] e [BELOW] a empilham
+ * dentro do bloco de conteúdo, nunca no slot do controle (radio/checkbox/chevron).
+ */
 enum class OceanCardListItemTagAlignment {
     START,
-    END
+    END,
+    ABOVE,
+    BELOW
 }
 
 @Composable
@@ -239,6 +247,12 @@ private fun CenterContent(
     Column(
         modifier = modifier
     ) {
+        if (tagStyle != null && tagAlignment == OceanCardListItemTagAlignment.ABOVE) {
+            OceanTag(style = tagStyle)
+
+            OceanSpacing.StackXXS()
+        }
+
         when (tagAlignment) {
             OceanCardListItemTagAlignment.START -> {
                 Row(
@@ -266,6 +280,16 @@ private fun CenterContent(
                     )
                 }
             }
+            OceanCardListItemTagAlignment.ABOVE,
+            OceanCardListItemTagAlignment.BELOW -> {
+                // A tag é emitida fora da linha do título, acima ou abaixo do bloco de texto.
+                TitleWithTag(
+                    title = title,
+                    contentStyle = contentStyle,
+                    tagStyle = null,
+                    disabled = disabled
+                )
+            }
         }
 
         if (description.isNotBlank()) {
@@ -284,6 +308,12 @@ private fun CenterContent(
                 style = OceanTextStyle.captionBold,
                 color = if (disabled) OceanColors.interfaceDarkUp else Color.Unspecified
             )
+        }
+
+        if (tagStyle != null && tagAlignment == OceanCardListItemTagAlignment.BELOW) {
+            OceanSpacing.StackXXS()
+
+            OceanTag(style = tagStyle)
         }
     }
 }
@@ -411,6 +441,45 @@ fun OceanCardListItemPreview() {
                     type = OceanTagType.Positive
                 ),
                 tagAlignment = OceanCardListItemTagAlignment.END
+            )
+
+            OceanCardListItem(
+                title = "Title with Tag Above",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = OceanTagStyle.Default(
+                    label = "3x sem acréscimo",
+                    layout = OceanTagLayout.Medium(),
+                    type = OceanTagType.Positive
+                ),
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE
+            )
+
+            OceanCardListItem(
+                title = "Title with Tag Below",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = OceanTagStyle.Default(
+                    label = "3x sem acréscimo",
+                    layout = OceanTagLayout.Medium(),
+                    type = OceanTagType.Positive
+                ),
+                tagAlignment = OceanCardListItemTagAlignment.BELOW
+            )
+
+            OceanCardListItem(
+                title = "Selectable with Tag Above",
+                description = "Description",
+                tagStyle = OceanTagStyle.Default(
+                    label = "3x sem acréscimo",
+                    layout = OceanTagLayout.Medium(),
+                    type = OceanTagType.Positive
+                ),
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE,
+                type = OceanCardListItemType.Selectable(
+                    selectionType = OceanCardListItemType.Selectable.SelectionType.Radiobutton,
+                    didUpdate = {}
+                )
             )
 
             OceanCardListItem(

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
@@ -13,8 +13,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
- * Cobre a prop [OceanCardListItemTagAlignment] — em especial os valores ABOVE e BELOW
- * acrescentados pelo MR-554, e a não-regressão dos valores preexistentes (RN-01).
+ * Covers the [OceanCardListItemTagAlignment] prop — especially the ABOVE and BELOW values
+ * added by MR-554, and the non-regression of the pre-existing values (RN-01).
  */
 @RunWith(RobolectricTestRunner::class)
 class OceanCardListItemTagAlignmentTest {
@@ -29,7 +29,7 @@ class OceanCardListItemTagAlignmentTest {
         type = OceanTagType.Positive
     )
 
-    // CT-16 — não-regressão: os valores preexistentes seguem renderizando a tag
+    // CT-16 — non-regression: the pre-existing values keep rendering the tag
 
     @Test
     fun rendersTagWhenAlignmentIsOmitted() {

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
@@ -1,0 +1,146 @@
+package br.com.useblu.oceands.components.compose.cardlistitem
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import br.com.useblu.oceands.components.compose.OceanTagLayout
+import br.com.useblu.oceands.components.compose.OceanTagStyle
+import br.com.useblu.oceands.components.compose.cardlistitem.model.OceanCardListItemType
+import br.com.useblu.oceands.model.OceanTagType
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Cobre a prop [OceanCardListItemTagAlignment] — em especial os valores ABOVE e BELOW
+ * acrescentados pelo MR-554, e a não-regressão dos valores preexistentes (RN-01).
+ */
+@RunWith(RobolectricTestRunner::class)
+class OceanCardListItemTagAlignmentTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    private val tagLabel = "3x sem acréscimo"
+
+    private val tagStyle = OceanTagStyle.Default(
+        label = tagLabel,
+        layout = OceanTagLayout.Medium(),
+        type = OceanTagType.Positive
+    )
+
+    // CT-16 — não-regressão: os valores preexistentes seguem renderizando a tag
+
+    @Test
+    fun rendersTagWhenAlignmentIsOmitted() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                tagStyle = tagStyle
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersTagWithStartAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.START
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersTagWithEndAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.END
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+    }
+
+    // CT-17 — valores novos
+
+    @Test
+    fun rendersTagWithAboveAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Caption").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersTagWithBelowAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.BELOW
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Caption").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersTagAboveWhenSelectable() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE,
+                type = OceanCardListItemType.Selectable(
+                    selectionType = OceanCardListItemType.Selectable.SelectionType.Radiobutton,
+                    didUpdate = {}
+                )
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    }
+
+    // CT-18 — posição informada sem tag não deve renderizar nada de tag
+
+    @Test
+    fun rendersNoTagWhenTagStyleIsNull() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                tagStyle = null,
+                tagAlignment = OceanCardListItemTagAlignment.ABOVE
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText(tagLabel).assertDoesNotExist()
+    }
+}


### PR DESCRIPTION
## Contexto

A tela de seleção de benefícios do PagBlu ([MR-523](https://useblu.atlassian.net/browse/MR-523)) posiciona a tag `%{installments}x sem acréscimo` **acima do título** do card. Hoje o `OceanCardListItem` só posiciona a tag na mesma linha do título — `START` (antes) ou `END` (depois) —, então a tela sairia com layout montado por fora do componente e o DS deixaria de ser a fonte da verdade.

Subtarefa **MR-554** de [MR-552](https://useblu.atlassian.net/browse/MR-552). Spec: [Ledger](https://github.com/Pagnet/product-bluprints/blob/main/prd-tracking/MR-552-indicator-position/MR-552-indicator-position-ledger.md).

## O que muda

```kotlin
enum class OceanCardListItemTagAlignment { START, END, ABOVE, BELOW }
```

Nos valores novos a tag deixa a linha do título e é empilhada **dentro do bloco de conteúdo**, com `OceanSpacing.StackXXS()` (8dp) de separação — o mesmo token do design-lock. O `CenterContent` já é uma `Column` alinhada à esquerda, então a tag fica *hug* naturalmente.

O layout vive num ponto só: o `when (tagAlignment)` do `CenterContent`. `ABOVE`/`BELOW` chamam `TitleWithTag(tagStyle = null)` e a tag é emitida separadamente, antes ou depois do bloco de texto.

## Não é breaking

- `START` segue sendo o default; `START` e `END` renderizam exatamente como antes.
- O único call site do ecossistema (`blu-mobile-android`, `SalePaymentMethodFragment.kt:202`, usa `END`) **não precisa mudar** — varredura em `org:Pagnet` + `org:ocean-ds`.
- Call sites atribuem o valor; não há `when` exaustivo sobre o enum fora da lib.
- `isTagAlignedEndWithSelectable` testa `== END`, então os valores novos caem naturalmente no caminho interno ao `CenterContent` — que é onde devem ficar. Nenhuma mudança nessa flag.

> O rename de `tagAlignment` para `indicatorPosition` **não** faz parte deste PR — fica no [MR-556](https://useblu.atlassian.net/browse/MR-556), junto com a remoção dos valores sem consumidor.

## Testes

`OceanCardListItemTagAlignmentTest` — 7 casos, todos verdes:

| Caso | Cobre |
|---|---|
| `rendersTagWhenAlignmentIsOmitted`, `rendersTagWithStartAlignment`, `rendersTagWithEndAlignment` | não-regressão dos valores preexistentes |
| `rendersTagWithAboveAlignment`, `rendersTagWithBelowAlignment` | valores novos, com description e caption |
| `rendersTagAboveWhenSelectable` | `ABOVE` + `Selectable(Radiobutton)` — o caso do MR-523 |
| `rendersNoTagWhenTagStyleIsNull` | posição informada sem tag não renderiza nada |

Suíte completa do `ocean-components`: **49 testes, 0 falhas**. `ktlintCheck` limpo.

## Previews

Acrescentadas ao showcase: `Title with Tag Above`, `Title with Tag Below` e `Selectable with Tag Above`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ocean-ds/ocean-android/pull/1103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->