### PR TITLE
feat(status-list-item): adiciona leadingIcon ao OceanStatusListItem

### DIFF
--- a/app/src/main/java/br/com/useblu/oceands/client/ui/statuslistitem/StatusListItemActivity.kt
+++ b/app/src/main/java/br/com/useblu/oceands/client/ui/statuslistitem/StatusListItemActivity.kt
@@ -1,30 +1,16 @@
 package br.com.useblu.oceands.client.ui.statuslistitem
 
 import android.os.Bundle
-import android.widget.Toast
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.databinding.DataBindingUtil
-import androidx.lifecycle.ViewModelProvider
-import br.com.useblu.oceands.client.R
-import br.com.useblu.oceands.client.databinding.ActivityStatusListItemBinding
+import br.com.useblu.oceands.components.compose.OceanStatusListItemPreview
 
 class StatusListItemActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityStatusListItemBinding
-    private lateinit var viewModel: StatusListItemViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_status_list_item)
-        binding.lifecycleOwner = this
-
-        viewModel = ViewModelProvider(this)[StatusListItemViewModel::class.java]
-        binding.viewmodel = viewModel
-        initObservers()
-    }
-
-    private fun initObservers() {
-        viewModel.touchItem.observe(this) {
-            Toast.makeText(this, it, Toast.LENGTH_SHORT).show()
+        setContent {
+            OceanStatusListItemPreview()
         }
     }
 }

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanStatusListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanStatusListItem.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,7 +35,11 @@ fun OceanStatusListItemPreview() {
     MaterialTheme {
         Column(
             verticalArrangement = Arrangement.spacedBy(10.dp),
-            modifier = Modifier.padding(20.dp)
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(OceanColors.interfaceLightUp)
+                .padding(20.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             OceanStatusListItem(
                 title = "Title",

--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanStatusListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/OceanStatusListItem.kt
@@ -145,6 +145,42 @@ fun OceanStatusListItemPreview() {
                     println("click container")
                 }
             )
+
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE,
+                onClick = {
+                    println("click container")
+                }
+            )
+
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                leadingIcon = OceanIcons.DOCUMENT_TEXT_OUTLINE,
+                tagLabel = "Tag",
+                tagType = OceanTagType.Warning,
+                tagPosition = OceanStatusListItemTagPosition.RIGHT,
+                rightIconType = OceanStatusListItemRightIconType.CONTEXT_MENU,
+                onClick = {
+                    println("click container")
+                },
+                onClickRightIcon = {
+                    println("click right icon")
+                }
+            )
+
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE,
+                isInactive = true,
+                onClick = {
+                    println("click container")
+                }
+            )
         }
     }
 }
@@ -165,6 +201,7 @@ fun OceanStatusListItem(
     badgeType: OceanBadgeType? = null,
     isReadOnly: Boolean = false,
     isInactive: Boolean = false,
+    leadingIcon: OceanIcons? = null,
     rightIconType: OceanStatusListItemRightIconType = OceanStatusListItemRightIconType.CHEVRON,
     onClick: (() -> Unit)? = null,
     onClickRightIcon: (() -> Unit)? = null
@@ -180,6 +217,16 @@ fun OceanStatusListItem(
             .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        if (leadingIcon != null) {
+            OceanIcon(
+                iconType = leadingIcon,
+                modifier = Modifier.size(24.dp),
+                tint = if (isInactive) OceanColors.interfaceDarkUp else OceanColors.brandPrimaryDown
+            )
+
+            OceanSpacing.StackXXSExtra()
+        }
+
         Column(
             modifier = Modifier.weight(1f)
         ) {

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanStatusListItemLeadingIconTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/OceanStatusListItemLeadingIconTest.kt
@@ -1,0 +1,117 @@
+package br.com.useblu.oceands.components.compose
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import br.com.useblu.oceands.model.OceanTagType
+import br.com.useblu.oceands.utils.OceanIcons
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Covers the [OceanStatusListItem] leadingIcon prop, mirroring the OceanCardListItem contract,
+ * and the non-regression of the item without a leading icon.
+ */
+@RunWith(RobolectricTestRunner::class)
+class OceanStatusListItemLeadingIconTest {
+
+    @get:Rule val composeTestRule = createComposeRule()
+
+    @Test
+    fun rendersContentWhenLeadingIconIsOmitted() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption"
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Caption").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersContentWithLeadingIcon() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Caption").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersLeadingIconWithTagAndBadge() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                leadingIcon = OceanIcons.DOCUMENT_TEXT_OUTLINE,
+                tagLabel = "Tag",
+                tagType = OceanTagType.Warning,
+                tagPosition = OceanStatusListItemTagPosition.RIGHT,
+                badge = "9"
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Tag").assertIsDisplayed()
+        composeTestRule.onNodeWithText("9").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersLeadingIconWhenReadOnly() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE,
+                isReadOnly = true
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersLeadingIconWhenInactive() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                description = "Description",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE,
+                isInactive = true,
+                onClick = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersLeadingIconWithContextMenuRightIcon() {
+        composeTestRule.setContent {
+            OceanStatusListItem(
+                title = "Title",
+                leadingIcon = OceanIcons.PAGBLU_OUTLINE,
+                rightIconType = OceanStatusListItemRightIconType.CONTEXT_MENU,
+                onClick = {},
+                onClickRightIcon = {}
+            )
+        }
+
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## O que muda

`OceanStatusListItem` passa a aceitar `leadingIcon`, seguindo o mesmo contrato já existente no `OceanCardListItem`.

- `leadingIcon: OceanIcons? = null`, posicionado antes de `rightIconType` para não quebrar chamadas por posição.
- Renderizado via `OceanIcon` no início da `Row`: 24dp, tint `brandPrimaryDown` (`interfaceDarkUp` quando `isInactive`), seguido de `OceanSpacing.StackXXSExtra()` (12dp) — mesmo tratamento do `LeadingDefaultTypeCardListItem`.

Quem não passar `leadingIcon` não tem nenhuma mudança visual.

## App de demo

`StatusListItemActivity` agora renderiza o `OceanStatusListItemPreview` via `setContent`, no mesmo padrão das telas já convertidas (`TextListItemActivity`, `CardReadOnlyActivity`) — antes ela só mostrava o componente XML legado por databinding, então o componente Compose não tinha tela no app.

Para isso a `Column` do preview ganhou `verticalScroll`, senão os itens do fim ficam fora da tela.

`activity_status_list_item.xml` e `StatusListItemViewModel` continuam no repo (não são mais referenciados pela activity), preservando a demo do componente XML legado caso alguém queira apontar uma tela para ela. Na conversão equivalente do TextListItem (#889) esses arquivos foram deletados — aqui optamos por manter.

## Paridade iOS

Mesma feature em https://github.com/ocean-ds/ocean-ios/pull/702 — `leadingIcon` no `StatusListItem` SwiftUI.

Uma divergência consciente: para o estado inativo usei `interfaceDarkUp`, que é o que o próprio `StatusListItem` já usa no texto inativo e o que o `CardListItem` do iOS usa como `disabledColor`. O `LeadingDefaultTypeCardListItem` usa `interfaceLightDeep` quando desabilitado — divergência que já existia entre as plataformas e que não propaguei.

## Fora do escopo

O componente XML/databinding `ocean_status_list_item` não recebeu `leadingIcon` — só a versão Compose, que é onde o `CardListItem` existe.

## Testes

`OceanStatusListItemLeadingIconTest.kt` (6 testes, Robolectric + compose rule, no mesmo formato do `OceanCardListItemTagAlignmentTest`): sem ícone (não-regressão), com ícone, com tag + badge, `isReadOnly`, `isInactive` e com `CONTEXT_MENU`.

```
./gradlew :ocean-components:testDebugUnitTest --tests "*OceanStatusListItemLeadingIconTest*"
BUILD SUCCESSFUL — tests="6" skipped="0" failures="0" errors="0"

./gradlew :app:assembleDebug
BUILD SUCCESSFUL

./gradlew :ocean-components:ktlintCheck :ocean-components:ktlintTestSourceSetCheck :app:ktlintCheck
BUILD SUCCESSFUL
```

Três previews novas em `OceanStatusListItemPreview` (só ícone, ícone + tag à direita + context menu, ícone inativo) validam o visual, agora também no app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)