### PR TITLE
feat(card-list-item): adiciona END_CENTER ao tagAlignment

### DIFF
--- a/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
+++ b/ocean-components/src/main/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItem.kt
@@ -54,10 +54,13 @@ import br.com.useblu.oceands.utils.vibrator.rememberVibrator
  *
  * [START] and [END] keep the tag on the same line as the title; [ABOVE] and [BELOW] stack it
  * inside the content block, never in the control slot (radio/checkbox/chevron).
+ * [END_CENTER] takes the tag out of the title line and centers it vertically against the whole
+ * text block, so it does not compete for width with a long title.
  */
 enum class OceanCardListItemTagAlignment {
     START,
     END,
+    END_CENTER,
     ABOVE,
     BELOW
 }
@@ -186,7 +189,8 @@ internal fun ContentCardListItem(
     showChevron: Boolean = false
 ) {
     val hasSelectableType = type is OceanCardListItemType.Selectable
-    val isTagAlignedEndWithSelectable = tagAlignment == OceanCardListItemTagAlignment.END && hasSelectableType
+    val isTagOutsideTextBlock = tagAlignment == OceanCardListItemTagAlignment.END_CENTER ||
+        (tagAlignment == OceanCardListItemTagAlignment.END && hasSelectableType)
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -205,12 +209,16 @@ internal fun ContentCardListItem(
             description = description,
             caption = caption,
             contentStyle = contentStyle,
-            tagStyle = if (isTagAlignedEndWithSelectable) null else tagStyle,
+            tagStyle = if (isTagOutsideTextBlock) null else tagStyle,
             tagAlignment = tagAlignment,
             disabled = disabled
         )
 
-        if (isTagAlignedEndWithSelectable && tagStyle != null) {
+        if (isTagOutsideTextBlock && tagStyle != null) {
+            if (tagAlignment == OceanCardListItemTagAlignment.END_CENTER) {
+                OceanSpacing.StackXXS()
+            }
+
             OceanTag(
                 style = tagStyle
             )
@@ -280,9 +288,10 @@ private fun CenterContent(
                     )
                 }
             }
+            OceanCardListItemTagAlignment.END_CENTER,
             OceanCardListItemTagAlignment.ABOVE,
             OceanCardListItemTagAlignment.BELOW -> {
-                // The tag is emitted outside the title line, above or below the text block.
+                // The tag is emitted outside the title line — above, below, or beside the block.
                 TitleWithTag(
                     title = title,
                     contentStyle = contentStyle,
@@ -734,6 +743,23 @@ fun OceanCardListItemTagPositionPreview() {
                 caption = "Caption",
                 tagStyle = tag,
                 tagAlignment = OceanCardListItemTagAlignment.END
+            )
+
+            OceanCardListItem(
+                title = "END_CENTER",
+                description = "Pague em até 3x",
+                caption = "Caption",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.END_CENTER,
+                showChevron = true
+            )
+
+            OceanCardListItem(
+                title = "END_CENTER com título longo que ocupa mais de uma linha",
+                description = "Pague em até 3x",
+                tagStyle = tag,
+                tagAlignment = OceanCardListItemTagAlignment.END_CENTER,
+                showChevron = true
             )
 
             OceanCardListItem(

--- a/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
+++ b/ocean-components/src/test/java/br/com/useblu/oceands/components/compose/cardlistitem/OceanCardListItemTagAlignmentTest.kt
@@ -1,12 +1,14 @@
 package br.com.useblu.oceands.components.compose.cardlistitem
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.getBoundsInRoot
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import br.com.useblu.oceands.components.compose.OceanTagLayout
 import br.com.useblu.oceands.components.compose.OceanTagStyle
 import br.com.useblu.oceands.components.compose.cardlistitem.model.OceanCardListItemType
 import br.com.useblu.oceands.model.OceanTagType
+import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -68,6 +70,73 @@ class OceanCardListItemTagAlignmentTest {
             )
         }
 
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersTagWithEndCenterAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.END_CENTER,
+                showChevron = true
+            )
+        }
+
+        composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Title").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Description").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Caption").assertIsDisplayed()
+
+        val titleBounds = composeTestRule.onNodeWithText("Title").getBoundsInRoot()
+        val captionBounds = composeTestRule.onNodeWithText("Caption").getBoundsInRoot()
+        val tagBounds = composeTestRule.onNodeWithText(tagLabel).getBoundsInRoot()
+        val tagCenterY = (tagBounds.top + tagBounds.bottom) / 2f
+
+        Assert.assertTrue(tagCenterY > (titleBounds.top + titleBounds.bottom) / 2f)
+        Assert.assertTrue(tagCenterY < (captionBounds.top + captionBounds.bottom) / 2f)
+    }
+
+    @Test
+    fun rendersTagOnTitleLineWithEndAlignment() {
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = "Title",
+                description = "Description",
+                caption = "Caption",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.END
+            )
+        }
+
+        val titleBounds = composeTestRule.onNodeWithText("Title").getBoundsInRoot()
+        val tagBounds = composeTestRule.onNodeWithText(tagLabel).getBoundsInRoot()
+
+        Assert.assertEquals(
+            (titleBounds.top + titleBounds.bottom).value / 2f,
+            (tagBounds.top + tagBounds.bottom).value / 2f,
+            0.5f
+        )
+    }
+
+    @Test
+    fun rendersTagWithEndCenterAlignmentWhenTitleIsLong() {
+        val longTitle = "Ana Sócia Administradora QSA do grupo econômico"
+
+        composeTestRule.setContent {
+            OceanCardListItem(
+                title = longTitle,
+                description = "Description",
+                tagStyle = tagStyle,
+                tagAlignment = OceanCardListItemTagAlignment.END_CENTER,
+                showChevron = true
+            )
+        }
+
+        composeTestRule.onNodeWithText(longTitle).assertIsDisplayed()
         composeTestRule.onNodeWithText(tagLabel).assertIsDisplayed()
     }
 


### PR DESCRIPTION
## Contexto

A tela de acompanhamento de convites de representante legal ([SHOW-146](https://useblu.atlassian.net/browse/SHOW-146), `blu-mobile-android`) lista os convites com `OceanCardListItem` de duas linhas (nome + e-mail) e tag de status à direita (`Pendente`/`Expirado`), usando `tagAlignment = END`.

Dois problemas aparecem nesse arranjo:

1. **A tag não acompanha o bloco de texto.** Com `END` ela fica na linha do título, encostada no topo do card, e não centralizada em relação a nome + e-mail.
2. **A tag é cortada.** No caminho da linha do título o `Row` é `SpaceBetween` + `fillMaxWidth` e o `OceanText` do título não tem `weight` nem `overflow`: um nome longo (`Ana Sócia Administradora QSA`) consome a largura e a tag é espremida — `Pendente` renderiza como `Pende`.

O componente **já resolve os dois**, mas só quando o tipo é `Selectable`: nesse caso a tag sai do `CenterContent` e é emitida no `Row` externo. Este PR expõe esse mesmo comportamento como um valor de alinhamento, em vez de deixar cada tela remontar a `Row` por fora do DS.

## O que muda

```kotlin
enum class OceanCardListItemTagAlignment { START, END, END_CENTER, ABOVE, BELOW }
```

```kotlin
val isTagOutsideTextBlock = tagAlignment == END_CENTER ||
    (tagAlignment == END && hasSelectableType)   // era só a segunda condição
```

Com `END_CENTER` a tag é emitida no `Row` externo do `ContentCardListItem`, que já é `verticalAlignment = Alignment.CenterVertically` e já dá `weight(1f)` ao bloco de texto. Consequências:

- a tag fica centralizada verticalmente contra título + descrição + caption;
- a tag mantém a largura intrínseca e é o **título** que quebra linha, em vez de a tag ser cortada.

`OceanSpacing.StackXXS()` (8dp, mesmo token dos outros gaps do componente) separa o texto da tag — aplicado **somente** em `END_CENTER`, para não alterar um pixel do `END + Selectable` já publicado.

No `when (tagAlignment)` do `CenterContent`, `END_CENTER` entra junto de `ABOVE`/`BELOW`, que renderizam `TitleWithTag(tagStyle = null)`.

## Não é breaking

- `START` segue o default; `START`, `END`, `ABOVE` e `BELOW` renderizam exatamente como antes — inclusive `END + Selectable`, cujo caminho não recebeu o novo espaçamento.
- Valor **aditivo**: nenhum call site precisa mudar. Não há `when` exaustivo sobre o enum fora da lib.
- `DefaultCardListItem` e `HighlightedCardListItem` passam os dois pelo `ContentCardListItem`, então `END_CENTER` vale nos dois estilos.

> A alternativa considerada era generalizar `END` (dropar o `hasSelectableType`), o que consertaria as telas existentes sem novo valor — mas mudaria o visual de todo item `Default` com tag `END` **e** descrição. Ficou de fora de propósito; se o design preferir esse caminho, `END_CENTER` deixa de ser necessário. Vale avaliar junto do rename previsto em [MR-556](https://useblu.atlassian.net/browse/MR-556).

## Testes

`OceanCardListItemTagAlignmentTest` — 10 casos, todos verdes. Os novos asseram **posição real** via `getBoundsInRoot()`, não só renderização:

| Caso | Cobre |
|---|---|
| `rendersTagWithEndCenterAlignment` | centro Y da tag entre o centro do título e o do caption — prova a centralização |
| `rendersTagOnTitleLineWithEndAlignment` | não-regressão: com `END`, centro da tag coincide com o do título (delta 0,5) |
| `rendersTagWithEndCenterAlignmentWhenTitleIsLong` | título longo + tag, ambos exibidos (o caso do corte) |

Suíte completa do `ocean-components`: **58 testes, 0 falhas**. `ktlintCheck` limpo.

## Previews

`OceanCardListItemTagPositionPreview` ganhou duas entradas `END_CENTER` — uma com description + caption + chevron, outra com título longo o suficiente para quebrar linha, que é onde a diferença contra `END` fica evidente.

<img width="396" height="669" alt="Screenshot 2026-08-11 at 15 08 00" src="https://github.com/user-attachments/assets/bc2aa3fa-9385-4004-a4f7-31e676ad8b51" />


## Consumo

Depende de release para o `blu-mobile-android` usar: hoje o app está em `oceanComponents = "3.8.2-973"`, que é o HEAD do `master`. Depois do release, o bump precisa sair em `blu-mobile-android` **e** em `mobile-android-architecture` — o version guard do `settings.gradle` do app falha se as duas versões divergirem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
